### PR TITLE
Add Directional Air Dodge

### DIFF
--- a/src/common/consts.rs
+++ b/src/common/consts.rs
@@ -260,6 +260,7 @@ pub enum MashInNeutral {
 pub struct TrainingModpackMenu {
     pub hitbox_vis: HitboxVisualization,
     pub di_state: Direction,
+    pub left_stick: Direction, // Currently only used for air dodge direction
     pub mash_attack_state: Attack,
     pub ledge_state: LedgeOption,
     pub tech_state: TechOption,

--- a/src/common/consts.rs
+++ b/src/common/consts.rs
@@ -1,3 +1,4 @@
+use core::f64::consts::PI;
 use smash::lib::lua_const::*;
 
 /// Hitbox Visualization
@@ -19,7 +20,7 @@ pub enum HitboxVisualization {
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Direction {
     None = 0,
-    Right =1,
+    Right = 1,
     UpRight = 2,
     Up = 3,
     UpLeft = 4,
@@ -46,6 +47,18 @@ impl From<i32> for Direction {
             9 => Direction::Random,
             _ => panic!("Invalid direction {}", x),
         }
+    }
+}
+
+
+//pub static FIGHTER_FACING_LEFT: f32 = 1.0;
+pub static FIGHTER_FACING_RIGHT: f32 = -1.0;
+pub static ANGLE_NONE: f64 = -69.0;
+pub fn direction_to_angle(direction: Direction) -> f64 {
+    match direction {
+        Direction::None => ANGLE_NONE,
+        Direction::Random => ANGLE_NONE, // Random Direction should be handled by the calling context
+        _ => (direction as i32 - 1) as f64 * PI / 4.0,
     }
 }
 
@@ -254,5 +267,5 @@ pub struct TrainingModpackMenu {
     pub shield_state: Shield,
     pub defensive_state: Defensive,
     pub oos_offset: i32,
-    pub mash_in_neutral: MashInNeutral
+    pub mash_in_neutral: MashInNeutral,
 }

--- a/src/common/consts.rs
+++ b/src/common/consts.rs
@@ -17,10 +17,36 @@ pub enum HitboxVisualization {
 /// DI
 #[repr(i32)]
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub enum DirectionalInfluence {
+pub enum Direction {
     None = 0,
+    Right =1,
+    UpRight = 2,
+    Up = 3,
+    UpLeft = 4,
+    Left = 5,
+    DownLeft = 6,
+    Down = 7,
+    DownRight = 8,
     // lol what goes here jug smh my head
-    RandomInAway = 9,
+    Random = 9,
+}
+
+impl From<i32> for Direction {
+    fn from(x: i32) -> Self {
+        match x {
+            0 => Direction::None,
+            1 => Direction::Right,
+            2 => Direction::UpRight,
+            3 => Direction::Up,
+            4 => Direction::UpLeft,
+            5 => Direction::Left,
+            6 => Direction::DownLeft,
+            7 => Direction::Down,
+            8 => Direction::DownRight,
+            9 => Direction::Random,
+            _ => panic!("Invalid direction {}", x),
+        }
+    }
 }
 
 /// Mash Attack States
@@ -220,7 +246,7 @@ pub enum MashInNeutral {
 #[repr(C)]
 pub struct TrainingModpackMenu {
     pub hitbox_vis: HitboxVisualization,
-    pub di_state: DirectionalInfluence,
+    pub di_state: Direction,
     pub mash_attack_state: Attack,
     pub ledge_state: LedgeOption,
     pub tech_state: TechOption,

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -7,7 +7,7 @@ use smash::lib::lua_const::*;
 
 pub static mut MENU_STRUCT: consts::TrainingModpackMenu = consts::TrainingModpackMenu {
     hitbox_vis: HitboxVisualization::On,
-    di_state: DirectionalInfluence::None,
+    di_state: Direction::None,
     mash_attack_state: Attack::Nair,
     ledge_state: LedgeOption::Random,
     tech_state: TechOption::Random,

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -8,6 +8,7 @@ use smash::lib::lua_const::*;
 pub static mut MENU_STRUCT: consts::TrainingModpackMenu = consts::TrainingModpackMenu {
     hitbox_vis: HitboxVisualization::On,
     di_state: Direction::None,
+    left_stick: Direction::None,
     mash_attack_state: Attack::Nair,
     ledge_state: LedgeOption::Random,
     tech_state: TechOption::Random,

--- a/src/training/directional_influence.rs
+++ b/src/training/directional_influence.rs
@@ -8,7 +8,6 @@ use smash::lib::L2CValue;
 use smash::lua2cpp::L2CFighterCommon;
 
 pub static mut DI_ANGLE: f64 = 0.0;
-pub static NO_DI: f64 = -69.0;
 
 #[skyline::hook(replace = smash::lua2cpp::L2CFighterCommon_FighterStatusDamage__correctDamageVectorCommon)]
 pub unsafe fn handle_correct_damage_vector_common(
@@ -37,16 +36,16 @@ unsafe fn mod_handle_di(fighter: &mut L2CFighterCommon, _arg1: L2CValue) {
     if MENU.di_state == Direction::Random {
         DI_ANGLE = get_random_di();
     } else {
-        DI_ANGLE = (MENU.di_state as i32 - 1) as f64 * PI / 4.0;
+        DI_ANGLE = direction_to_angle(MENU.di_state)
     }
 
     // If facing left, reverse angle
-    if DI_ANGLE != NO_DI && PostureModule::lr(module_accessor) != -1.0 {
+    if DI_ANGLE != ANGLE_NONE && PostureModule::lr(module_accessor) != FIGHTER_FACING_RIGHT {
         DI_ANGLE -= PI;
     }
 
     // Nothig to do on no DI
-    if DI_ANGLE == NO_DI {
+    if DI_ANGLE == ANGLE_NONE {
         return;
     }
 
@@ -68,6 +67,6 @@ unsafe fn get_random_di() -> f64 {
         // Either 0 (right) or PI (left)
         rand as f64 * PI
     } else {
-        NO_DI
+        ANGLE_NONE
     }
 }

--- a/src/training/directional_influence.rs
+++ b/src/training/directional_influence.rs
@@ -24,7 +24,7 @@ unsafe fn mod_handle_di(fighter: &mut L2CFighterCommon, _arg1: L2CValue) {
         return;
     }
 
-    if MENU.di_state == DirectionalInfluence::None {
+    if MENU.di_state == Direction::None {
         return;
     }
 
@@ -34,7 +34,7 @@ unsafe fn mod_handle_di(fighter: &mut L2CFighterCommon, _arg1: L2CValue) {
     }
 
     // Either left, right, or none
-    if MENU.di_state == DirectionalInfluence::RandomInAway {
+    if MENU.di_state == Direction::Random {
         DI_ANGLE = get_random_di();
     } else {
         DI_ANGLE = (MENU.di_state as i32 - 1) as f64 * PI / 4.0;

--- a/src/training/directional_influence.rs
+++ b/src/training/directional_influence.rs
@@ -33,12 +33,7 @@ unsafe fn mod_handle_di(fighter: &mut L2CFighterCommon, _arg1: L2CValue) {
     }
 
     // Either left, right, or none
-    if MENU.di_state == Direction::Random {
-        DI_ANGLE = get_random_di();
-    } else {
-        DI_ANGLE = direction_to_angle(MENU.di_state)
-    }
-
+    DI_ANGLE = get_angle(MENU.di_state);
     // Nothig to do on no DI
     if DI_ANGLE == ANGLE_NONE {
         return;
@@ -61,12 +56,23 @@ unsafe fn mod_handle_di(fighter: &mut L2CFighterCommon, _arg1: L2CValue) {
     );
 }
 
-unsafe fn get_random_di() -> f64 {
+unsafe fn get_angle(direction: Direction) -> f64 {
+    if direction == Direction::Random {
+        let rand_direction = get_random_direction();
+        return direction_to_angle(rand_direction);
+    }
+
+    direction_to_angle(direction)
+}
+
+unsafe fn get_random_direction() -> Direction {
+    // Choose Left/Right/None
     let rand = app::sv_math::rand(hash40("fighter"), 3);
-    if [0, 1].contains(&rand) {
-        // Either 0 (right) or PI (left)
-        rand as f64 * PI
+    if rand == 0 {
+        Direction::Left
+    } else if rand == 1 {
+        Direction::Right
     } else {
-        ANGLE_NONE
+        Direction::None
     }
 }

--- a/src/training/directional_influence.rs
+++ b/src/training/directional_influence.rs
@@ -39,14 +39,14 @@ unsafe fn mod_handle_di(fighter: &mut L2CFighterCommon, _arg1: L2CValue) {
         DI_ANGLE = direction_to_angle(MENU.di_state)
     }
 
-    // If facing left, reverse angle
-    if DI_ANGLE != ANGLE_NONE && PostureModule::lr(module_accessor) != FIGHTER_FACING_RIGHT {
-        DI_ANGLE -= PI;
-    }
-
     // Nothig to do on no DI
     if DI_ANGLE == ANGLE_NONE {
         return;
+    }
+
+    // If facing left, reverse angle
+    if PostureModule::lr(module_accessor) != FIGHTER_FACING_RIGHT {
+        DI_ANGLE -= PI;
     }
 
     WorkModule::set_float(

--- a/src/training/left_stick.rs
+++ b/src/training/left_stick.rs
@@ -1,0 +1,84 @@
+use crate::common::consts::*;
+use crate::common::*;
+use core::f64::consts::PI;
+use smash::app::{self, lua_bind::*};
+use smash::hash40;
+use smash::lib::lua_const::*;
+
+static mut STICK_DIRECTION: Direction = Direction::None;
+
+pub unsafe fn mod_get_stick_x(
+    module_accessor: &mut app::BattleObjectModuleAccessor,
+) -> Option<f32> {
+    if !is_training_mode() {
+        return None;
+    }
+
+    if !is_operation_cpu(module_accessor) {
+        return None;
+    }
+
+    let status_kind = StatusModule::status_kind(module_accessor);
+    if !status_kind == FIGHTER_STATUS_KIND_ESCAPE_AIR {
+        return None;
+    }
+
+    STICK_DIRECTION = MENU.di_state;
+    let mut angle: f64 = get_angle(STICK_DIRECTION);
+
+    if angle == ANGLE_NONE {
+        return None;
+    }
+
+    // If facing left, reverse angle
+    if PostureModule::lr(module_accessor) != FIGHTER_FACING_RIGHT {
+        angle -= PI;
+    }
+
+    Some(angle.cos() as f32)
+}
+
+pub unsafe fn mod_get_stick_y(
+    module_accessor: &mut app::BattleObjectModuleAccessor,
+) -> Option<f32> {
+    if !is_training_mode() {
+        return None;
+    }
+
+    if !is_operation_cpu(module_accessor) {
+        return None;
+    }
+
+    let status_kind = StatusModule::status_kind(module_accessor);
+    if !status_kind == FIGHTER_STATUS_KIND_ESCAPE_AIR {
+        return None;
+    }
+
+    STICK_DIRECTION = MENU.di_state;
+    let mut angle: f64 = get_angle(STICK_DIRECTION);
+
+    if angle == ANGLE_NONE {
+        return None;
+    }
+
+    // If facing left, reverse angle
+    if PostureModule::lr(module_accessor) != FIGHTER_FACING_RIGHT {
+        angle -= PI;
+    }
+
+    Some(angle.sin() as f32)
+}
+
+unsafe fn get_angle(direction: Direction) -> f64 {
+    if direction == Direction::Random {
+        let rand_direction = get_random_direction();
+        return direction_to_angle(rand_direction);
+    }
+
+    direction_to_angle(direction)
+}
+
+unsafe fn get_random_direction() -> Direction {
+    let rand = app::sv_math::rand(hash40("fighter"), 8);
+    Direction::from(rand)
+}

--- a/src/training/left_stick.rs
+++ b/src/training/left_stick.rs
@@ -44,7 +44,7 @@ unsafe fn get_angle(module_accessor: &mut app::BattleObjectModuleAccessor) -> f6
         return ANGLE_NONE;
     }
 
-    STICK_DIRECTION = MENU.di_state;
+    STICK_DIRECTION = MENU.left_stick;
     let mut angle: f64 = pick_angle(STICK_DIRECTION);
 
     if angle == ANGLE_NONE {

--- a/src/training/left_stick.rs
+++ b/src/training/left_stick.rs
@@ -10,29 +10,10 @@ static mut STICK_DIRECTION: Direction = Direction::None;
 pub unsafe fn mod_get_stick_x(
     module_accessor: &mut app::BattleObjectModuleAccessor,
 ) -> Option<f32> {
-    if !is_training_mode() {
-        return None;
-    }
-
-    if !is_operation_cpu(module_accessor) {
-        return None;
-    }
-
-    let status_kind = StatusModule::status_kind(module_accessor);
-    if !status_kind == FIGHTER_STATUS_KIND_ESCAPE_AIR {
-        return None;
-    }
-
-    STICK_DIRECTION = MENU.di_state;
-    let mut angle: f64 = get_angle(STICK_DIRECTION);
+    let angle: f64 = get_angle(module_accessor);
 
     if angle == ANGLE_NONE {
         return None;
-    }
-
-    // If facing left, reverse angle
-    if PostureModule::lr(module_accessor) != FIGHTER_FACING_RIGHT {
-        angle -= PI;
     }
 
     Some(angle.cos() as f32)
@@ -41,24 +22,34 @@ pub unsafe fn mod_get_stick_x(
 pub unsafe fn mod_get_stick_y(
     module_accessor: &mut app::BattleObjectModuleAccessor,
 ) -> Option<f32> {
-    if !is_training_mode() {
-        return None;
-    }
-
-    if !is_operation_cpu(module_accessor) {
-        return None;
-    }
-
-    let status_kind = StatusModule::status_kind(module_accessor);
-    if !status_kind == FIGHTER_STATUS_KIND_ESCAPE_AIR {
-        return None;
-    }
-
-    STICK_DIRECTION = MENU.di_state;
-    let mut angle: f64 = get_angle(STICK_DIRECTION);
+    let angle: f64 = get_angle(module_accessor);
 
     if angle == ANGLE_NONE {
         return None;
+    }
+
+    Some(angle.sin() as f32)
+}
+
+unsafe fn get_angle(module_accessor: &mut app::BattleObjectModuleAccessor) -> f64 {
+    if !is_training_mode() {
+        return ANGLE_NONE;
+    }
+
+    if !is_operation_cpu(module_accessor) {
+        return ANGLE_NONE;
+    }
+
+    // Currently used for air dodge//Drift only
+    if !(is_airborne(module_accessor) && is_in_hitstun(module_accessor)) {
+        return ANGLE_NONE;
+    }
+
+    STICK_DIRECTION = MENU.di_state;
+    let mut angle: f64 = pick_angle(STICK_DIRECTION);
+
+    if angle == ANGLE_NONE {
+        return ANGLE_NONE;
     }
 
     // If facing left, reverse angle
@@ -66,10 +57,10 @@ pub unsafe fn mod_get_stick_y(
         angle -= PI;
     }
 
-    Some(angle.sin() as f32)
+    angle
 }
 
-unsafe fn get_angle(direction: Direction) -> f64 {
+unsafe fn pick_angle(direction: Direction) -> f64 {
     if direction == Direction::Random {
         let rand_direction = get_random_direction();
         return direction_to_angle(rand_direction);

--- a/src/training/left_stick.rs
+++ b/src/training/left_stick.rs
@@ -3,7 +3,6 @@ use crate::common::*;
 use core::f64::consts::PI;
 use smash::app::{self, lua_bind::*};
 use smash::hash40;
-use smash::lib::lua_const::*;
 
 static mut STICK_DIRECTION: Direction = Direction::None;
 

--- a/src/training/mash.rs
+++ b/src/training/mash.rs
@@ -179,7 +179,7 @@ pub unsafe fn check_button_on(
     }
 
     if MENU.mash_state == Mash::Airdodge
-        && !(is_in_hitstun(module_accessor)
+        && (is_in_hitstun(module_accessor)
             || is_in_landing(module_accessor)
             || is_in_footstool(module_accessor))
     {

--- a/src/training/mod.rs
+++ b/src/training/mod.rs
@@ -1,4 +1,5 @@
 use crate::common::FIGHTER_MANAGER_ADDR;
+use crate::common::*;
 use crate::hitbox_visualizer;
 use skyline::nn::ro::LookupSymbol;
 use smash::app::{self, lua_bind::*};
@@ -7,6 +8,7 @@ pub mod directional_influence;
 pub mod shield;
 pub mod tech;
 
+mod left_stick;
 mod ledge;
 mod mash;
 mod save_states;
@@ -54,6 +56,43 @@ pub unsafe fn handle_get_command_flag_cat(
     flag
 }
 
+/**
+ * This is called to get the stick position when
+ * shielding (shield tilt)
+ * 1 is fully right, -1 is fully left
+ */
+#[skyline::hook(replace = ControlModule::get_stick_x_no_clamp)]
+pub unsafe fn get_stick_x_no_clamp(module_accessor: &mut app::BattleObjectModuleAccessor) -> f32 {
+    left_stick::mod_get_stick_x(module_accessor).unwrap_or_else(|| original!()(module_accessor))
+}
+/**
+ * This is called to get the stick position when
+ * shielding (shield tilt)
+ * 1 is fully up, -1 is fully down
+ */
+#[skyline::hook(replace = ControlModule::get_stick_y_no_clamp)]
+pub unsafe fn get_stick_y_no_clamp(module_accessor: &mut app::BattleObjectModuleAccessor) -> f32 {
+    left_stick::mod_get_stick_y(module_accessor).unwrap_or_else(|| original!()(module_accessor))
+}
+
+/**
+ * Called when:
+ * Walking in the facing direction
+ * Air Dodging
+ */
+#[skyline::hook(replace = ControlModule::get_stick_x)]
+pub unsafe fn get_stick_x(module_accessor: &mut app::BattleObjectModuleAccessor) -> f32 {
+    left_stick::mod_get_stick_x(module_accessor).unwrap_or_else(|| original!()(module_accessor))
+}
+
+/**
+ *
+ */
+#[skyline::hook(replace = ControlModule::get_stick_y)]
+pub unsafe fn get_stick_y(module_accessor: &mut app::BattleObjectModuleAccessor) -> f32 {
+    left_stick::mod_get_stick_y(module_accessor).unwrap_or_else(|| original!()(module_accessor))
+}
+
 // int get_pad_flag(u64 module_accessor) {
 //     u64 control_module = load_module(module_accessor, 0x48);
 //     int (*get_pad_flag)(u64) = (int (*)(u64)) load_module_impl(control_module, 0x348);
@@ -78,13 +117,13 @@ pub unsafe fn handle_get_command_flag_cat(
 //     return stick_x;
 // }
 
-// float get_stick_y_replace(u64 module_accessor) {
+// float get_attack_air_stick_x_replace(u64 module_accessor) {
 //     u64 control_module = load_module(module_accessor, 0x48);
-//     float (*get_stick_y)(u64) = (float (*)(u64)) load_module_impl(control_module, 0x188);
-//     float stick_y = get_stick_y(control_module);
+//     float (*get_attack_air_stick_x)(u64) = (float (*)(u64)) load_module_impl(control_module, 0x188);
+//     float stick_y = get_attack_air_stick_x(control_module);
 
 //     bool replace;
-//     float ret = InputRecorder::get_stick_y(module_accessor, replace);
+//     float ret = InputRecorder::get_attack_air_stick_x(module_accessor, replace);
 //     if (replace) return ret;
 
 //     return stick_y;
@@ -161,6 +200,9 @@ pub fn training_mods() {
         handle_get_attack_air_kind,
         // Tech options
         handle_change_motion,
+        // Directional AirDodge,
+        get_stick_x,
+        get_stick_y,
     );
 
     // // Input recorder
@@ -168,6 +210,6 @@ pub fn training_mods() {
     //     "_ZN3app8lua_bind31ControlModule__get_stick_x_implEPNS_26BattleObjectModuleAccessorE",
     //     (u64)&ControlModule::get_stick_x_replace);
     // SaltySD_function_replace_sym(
-    //     "_ZN3app8lua_bind31ControlModule__get_stick_y_implEPNS_26BattleObjectModuleAccessorE",
-    //     (u64)&ControlModule::get_stick_y_replace);
+    //     "_ZN3app8lua_bind31ControlModule__get_attack_air_stick_x_implEPNS_26BattleObjectModuleAccessorE",
+    //     (u64)&ControlModule::get_attack_air_stick_x_replace);
 }

--- a/src/training/mod.rs
+++ b/src/training/mod.rs
@@ -1,5 +1,4 @@
 use crate::common::FIGHTER_MANAGER_ADDR;
-use crate::common::*;
 use crate::hitbox_visualizer;
 use skyline::nn::ro::LookupSymbol;
 use smash::app::{self, lua_bind::*};


### PR DESCRIPTION
- Added option for directional air dodges
- Renamed DirectionalInfluence enum to Direction
- Moved angle calculation to common
    - Renamed NO_DI to ANGLE_NONE and moved to common
- Fixed a bug where the CPU would always flash shield when Mash::AirDodge is set