### PR TITLE
Update Frame Advantage

### DIFF
--- a/src/common/consts.rs
+++ b/src/common/consts.rs
@@ -50,7 +50,6 @@ impl From<i32> for Direction {
     }
 }
 
-
 //pub static FIGHTER_FACING_LEFT: f32 = 1.0;
 pub static FIGHTER_FACING_RIGHT: f32 = -1.0;
 pub static ANGLE_NONE: f64 = -69.0;
@@ -268,5 +267,13 @@ pub struct TrainingModpackMenu {
     pub shield_state: Shield,
     pub defensive_state: Defensive,
     pub oos_offset: i32,
-    pub mash_in_neutral: MashInNeutral
+    pub mash_in_neutral: MashInNeutral,
+}
+
+// Fighter Ids
+#[repr(i32)]
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum FighterId {
+    Player = 0,
+    CPU = 1,
 }

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -16,7 +16,7 @@ pub static mut MENU_STRUCT: consts::TrainingModpackMenu = consts::TrainingModpac
     shield_state: Shield::None,
     defensive_state: Defensive::Random,
     oos_offset: 0,
-    mash_in_neutral: MashInNeutral::Off
+    mash_in_neutral: MashInNeutral::Off,
 };
 
 pub static mut MENU: &'static mut consts::TrainingModpackMenu = unsafe { &mut MENU_STRUCT };
@@ -54,12 +54,12 @@ pub unsafe fn is_operation_cpu(module_accessor: &mut app::BattleObjectModuleAcce
     FighterInformation::is_operation_cpu(fighter_information)
 }
 
-pub unsafe fn is_grounded(module_accessor: &mut app::BattleObjectModuleAccessor) ->bool{
+pub unsafe fn is_grounded(module_accessor: &mut app::BattleObjectModuleAccessor) -> bool {
     let situation_kind = StatusModule::situation_kind(module_accessor) as i32;
     situation_kind == SITUATION_KIND_GROUND
 }
 
-pub unsafe fn is_airborne(module_accessor: &mut app::BattleObjectModuleAccessor) ->bool{
+pub unsafe fn is_airborne(module_accessor: &mut app::BattleObjectModuleAccessor) -> bool {
     let situation_kind = StatusModule::situation_kind(module_accessor) as i32;
     situation_kind == SITUATION_KIND_AIR
 }
@@ -122,4 +122,25 @@ pub unsafe fn perform_defensive_option(
         Defensive::Jab => *flag |= *FIGHTER_PAD_CMD_CAT1_FLAG_ATTACK_N,
         _ => (),
     }
+}
+
+/**
+ * Returns true once per frame
+ */
+pub unsafe fn once_per_frame(
+    module_accessor: &mut app::BattleObjectModuleAccessor,
+    category: i32,
+) -> bool {
+    if category != 0 {
+        return false;
+    }
+
+    let entry_id_int =
+        WorkModule::get_int(module_accessor, *FIGHTER_INSTANCE_WORK_ID_INT_ENTRY_ID) as i32;
+    // do only once.
+    if entry_id_int != (FighterId::Player as i32) {
+        return false;
+    }
+
+    true
 }

--- a/src/training/combo.rs
+++ b/src/training/combo.rs
@@ -54,14 +54,7 @@ pub unsafe fn get_command_flag_cat(
         return;
     }
 
-    if category != 0 {
-        return;
-    }
-
-    let entry_id_int =
-        WorkModule::get_int(module_accessor, *FIGHTER_INSTANCE_WORK_ID_INT_ENTRY_ID) as i32;
-    // do only once.
-    if entry_id_int != (FighterId::Player as i32) {
+    if !once_per_frame(module_accessor, category) {
         return;
     }
 

--- a/src/training/combo.rs
+++ b/src/training/combo.rs
@@ -4,22 +4,12 @@ use crate::common::*;
 use crate::training::*;
 
 pub static mut FRAME_ADVANTAGE: i32 = 0;
-static mut FRAME_COUNTER: u64 = 0;
-static mut PLAYER_ACTIONABLE: bool = false;
-static mut CPU_ACTIONABLE: bool = false;
-static mut PLAYER_ACTIVE_FRAME: u64 = 0;
-static mut CPU_ACTIVE_FRAME: u64 = 0;
+static mut PLAYER_ACTIONABLE: bool = true;
+static mut CPU_ACTIONABLE: bool = true;
+static mut PLAYER_ACTIVE_FRAME: u32 = 0;
+static mut CPU_ACTIVE_FRAME: u32 = 0;
 static mut FRAME_ADVANTAGE_CHECK: bool = false;
-
-unsafe fn was_in_hitstun(module_accessor: *mut app::BattleObjectModuleAccessor) -> bool {
-    let prev_status = StatusModule::prev_status_kind(module_accessor, 0);
-    (*FIGHTER_STATUS_KIND_DAMAGE..=*FIGHTER_STATUS_KIND_DAMAGE_FALL).contains(&prev_status)
-}
-
-unsafe fn was_in_shieldstun(module_accessor: *mut app::BattleObjectModuleAccessor) -> bool {
-    let prev_status = StatusModule::prev_status_kind(module_accessor, 0);
-    prev_status == FIGHTER_STATUS_KIND_GUARD_DAMAGE
-}
+static mut SAVED_FRAME: u32 = 0;
 
 unsafe fn get_module_accessor(fighter_id: FighterId) -> *mut app::BattleObjectModuleAccessor {
     let entry_id_int = fighter_id as i32;
@@ -31,16 +21,23 @@ unsafe fn get_module_accessor(fighter_id: FighterId) -> *mut app::BattleObjectMo
 }
 
 unsafe fn is_actionable(module_accessor: *mut app::BattleObjectModuleAccessor) -> bool {
+    // Can Air Dodge
     WorkModule::is_enable_transition_term(
         module_accessor,
         *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_ESCAPE_AIR,
-    ) || WorkModule::is_enable_transition_term(
+    )
+    // Can perform an Aerial
+    || WorkModule::is_enable_transition_term(
         module_accessor,
         *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_ATTACK_AIR,
-    ) || WorkModule::is_enable_transition_term(
+    )
+    // Can Shield
+     || WorkModule::is_enable_transition_term(
         module_accessor,
         *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_GUARD_ON,
-    ) || WorkModule::is_enable_transition_term(
+    )
+    // Can Roll/Spot Dodge
+    || WorkModule::is_enable_transition_term(
         module_accessor,
         *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_ESCAPE,
     ) || CancelModule::is_enable_cancel(module_accessor)
@@ -59,7 +56,6 @@ pub unsafe fn get_command_flag_cat(
     }
 
     let player_module_accessor = get_module_accessor(FighterId::Player);
-    let cpu_module_accessor = get_module_accessor(FighterId::CPU);
 
     // Use to factor in that we should only update frame advantage if
     // there's been a hit that connects
@@ -69,40 +65,127 @@ pub unsafe fn get_command_flag_cat(
 
     // }
 
-    // the frame the fighter *becomes* actionable
-    if !CPU_ACTIONABLE && is_actionable(cpu_module_accessor) {
-        CPU_ACTIVE_FRAME = FRAME_COUNTER;
-    }
+    // Start frame counter when the player becomes inactionable
+    if PLAYER_ACTIONABLE && !is_actionable(player_module_accessor) {
+        // Some strings lock the CPU while the player can move, so we need to save the advantage
+        if PLAYER_ACTIVE_FRAME > 0 {
+            SAVED_FRAME = frame_counter::get_frame_count();
 
-    if !PLAYER_ACTIONABLE && is_actionable(player_module_accessor) {
-        PLAYER_ACTIVE_FRAME = FRAME_COUNTER;
-    }
+            println!("Saving Frame {}", SAVED_FRAME);
+        }
 
-    CPU_ACTIONABLE = is_actionable(cpu_module_accessor);
-    PLAYER_ACTIONABLE = is_actionable(player_module_accessor);
-
-    // if neither are active
-    if !CPU_ACTIONABLE && !PLAYER_ACTIONABLE {
+        frame_counter::reset_frame_count();
+        frame_counter::start_counting();
+        PLAYER_ACTIONABLE = false;
         FRAME_ADVANTAGE_CHECK = true;
+
+        println!("Starting Counter");
     }
 
-    // if both are now active
-    if PLAYER_ACTIONABLE && CPU_ACTIONABLE {
-        if FRAME_ADVANTAGE_CHECK {
-            if was_in_hitstun(cpu_module_accessor) || was_in_shieldstun(cpu_module_accessor) {
-                let frame_advantage: i64;
-                if PLAYER_ACTIVE_FRAME > CPU_ACTIVE_FRAME {
-                    frame_advantage = (PLAYER_ACTIVE_FRAME - CPU_ACTIVE_FRAME) as i64 * -1;
-                } else {
-                    frame_advantage = (CPU_ACTIVE_FRAME - PLAYER_ACTIVE_FRAME) as i64;
-                }
-
-                FRAME_ADVANTAGE = frame_advantage as i32;
-            }
-
-            FRAME_ADVANTAGE_CHECK = false;
+    // Nothing to do until we want to start checking
+    if !FRAME_ADVANTAGE_CHECK {
+        if !check_start_counter(player_module_accessor) {
+            return;
         }
     }
 
-    FRAME_COUNTER += 1;
+    check_cpu_frames();
+
+    // The frame the player becomes actionable again
+    if !PLAYER_ACTIONABLE && is_actionable(player_module_accessor) {
+        PLAYER_ACTIVE_FRAME = frame_counter::get_frame_count();
+        PLAYER_ACTIONABLE = true;
+        println!("Player FAF {}", PLAYER_ACTIVE_FRAME);
+    }
+
+    // When both are actionable again
+    if PLAYER_ACTIONABLE && CPU_ACTIONABLE {
+        calculate_frame_advantage(CPU_ACTIVE_FRAME, PLAYER_ACTIVE_FRAME);
+        reset();
+    }
+}
+
+/**
+ * Returns true if we just started counting
+ */
+unsafe fn check_start_counter(
+    player_module_accessor: *mut app::BattleObjectModuleAccessor,
+) -> bool {
+    // Nothing to do if we were inactionable from before
+    if !PLAYER_ACTIONABLE {
+        return false;
+    }
+
+    // Nothing to do if we are still actionable
+    if is_actionable(player_module_accessor) {
+        return false;
+    }
+
+    // Some strings lock the CPU while the player can move, so we need to save the advantage
+    if PLAYER_ACTIVE_FRAME > 0 {
+        SAVED_FRAME = frame_counter::get_frame_count();
+        println!("Saving Frame {}", SAVED_FRAME);
+    }
+
+    frame_counter::reset_frame_count();
+    frame_counter::start_counting();
+    PLAYER_ACTIONABLE = false;
+    FRAME_ADVANTAGE_CHECK = true;
+
+    println!("Starting Counter");
+    return true;
+}
+
+unsafe fn check_cpu_frames() {
+    let cpu_module_accessor = get_module_accessor(FighterId::CPU);
+
+    if is_actionable(cpu_module_accessor) {
+        // Nothing changed if we were already actionable
+        if CPU_ACTIONABLE {
+            return;
+        }
+
+        // Save The CPU Frame
+        CPU_ACTIVE_FRAME = frame_counter::get_frame_count();
+        CPU_ACTIONABLE = true;
+        println!("CPU FAF {}", CPU_ACTIVE_FRAME);
+
+        // Check combo advantage
+        if SAVED_FRAME != 0 {
+            calculate_frame_advantage(CPU_ACTIVE_FRAME, SAVED_FRAME);
+        }
+    } else {
+        CPU_ACTIONABLE = false;
+    }
+}
+
+// Calculate advantage and reset
+unsafe fn calculate_frame_advantage(cpu_frame: u32, player_frame: u32) {
+    // Don't count neutral frames
+    if player_frame <= 1 {
+        return;
+    }
+
+    let mut diff = (cpu_frame as i32) - (player_frame as i32);
+
+    // Fix diff for on whiff options
+    if cpu_frame <= 1{
+        diff +=2;
+    }
+
+    /*
+     * Convert to i32 to allow negative values
+     */
+    FRAME_ADVANTAGE = diff;
+
+    println!("{} - {} = {}", cpu_frame, player_frame, FRAME_ADVANTAGE);
+}
+
+unsafe fn reset() {
+    frame_counter::stop_counting();
+    CPU_ACTIVE_FRAME = 0;
+    PLAYER_ACTIVE_FRAME = 0;
+    SAVED_FRAME = 0;
+    FRAME_ADVANTAGE_CHECK = false;
+    println!("Resetting");
 }

--- a/src/training/combo.rs
+++ b/src/training/combo.rs
@@ -65,23 +65,6 @@ pub unsafe fn get_command_flag_cat(
 
     // }
 
-    // Start frame counter when the player becomes inactionable
-    if PLAYER_ACTIONABLE && !is_actionable(player_module_accessor) {
-        // Some strings lock the CPU while the player can move, so we need to save the advantage
-        if PLAYER_ACTIVE_FRAME > 0 {
-            SAVED_FRAME = frame_counter::get_frame_count();
-
-            println!("Saving Frame {}", SAVED_FRAME);
-        }
-
-        frame_counter::reset_frame_count();
-        frame_counter::start_counting();
-        PLAYER_ACTIONABLE = false;
-        FRAME_ADVANTAGE_CHECK = true;
-
-        println!("Starting Counter");
-    }
-
     // Nothing to do until we want to start checking
     if !FRAME_ADVANTAGE_CHECK {
         if !check_start_counter(player_module_accessor) {

--- a/src/training/combo.rs
+++ b/src/training/combo.rs
@@ -152,8 +152,8 @@ unsafe fn calculate_frame_advantage(cpu_frame: u32, player_frame: u32) {
     let mut diff = (cpu_frame as i32) - (player_frame as i32);
 
     // Fix diff for on whiff options
-    if cpu_frame <= 1{
-        diff +=2;
+    if cpu_frame <= 1 {
+        diff += 2;
     }
 
     /*

--- a/src/training/frame_counter.rs
+++ b/src/training/frame_counter.rs
@@ -1,0 +1,44 @@
+use crate::common::*;
+use crate::training::*;
+
+static mut CURRENT_FRAME : u32 = 0;
+static mut SHOULD_COUNT: bool = false;
+
+
+pub unsafe fn start_counting(){
+    SHOULD_COUNT = true;
+}
+
+pub unsafe fn stop_counting(){
+    SHOULD_COUNT = false;
+}
+
+pub unsafe fn reset_frame_count(){
+    CURRENT_FRAME = 0;
+}
+
+pub unsafe fn get_frame_count() -> u32 {
+    CURRENT_FRAME
+}
+
+pub unsafe fn tick(){
+    if SHOULD_COUNT{
+        CURRENT_FRAME += 1;
+        println!("Tick {}",CURRENT_FRAME);
+    }
+}
+
+pub unsafe fn get_command_flag_cat(
+    module_accessor: &mut app::BattleObjectModuleAccessor,
+    category: i32,
+) {
+    if !is_training_mode() {
+        return;
+    }
+
+    if !once_per_frame(module_accessor, category){
+        return;
+    }
+
+    tick();
+}

--- a/src/training/frame_counter.rs
+++ b/src/training/frame_counter.rs
@@ -1,30 +1,41 @@
 use crate::common::*;
 use crate::training::*;
 
-static mut CURRENT_FRAME : u32 = 0;
-static mut SHOULD_COUNT: bool = false;
+static mut SHOULD_COUNT: Vec<bool> = vec![];
+static mut COUNTERS: Vec<u32> = vec![];
 
+pub unsafe fn register_counter() -> usize {
+    let index = COUNTERS.len();
 
-pub unsafe fn start_counting(){
-    SHOULD_COUNT = true;
+    COUNTERS.push(0);
+    SHOULD_COUNT.push(false);
+
+    index
 }
 
-pub unsafe fn stop_counting(){
-    SHOULD_COUNT = false;
+pub unsafe fn start_counting(index:usize) {
+    SHOULD_COUNT[index] = true;
 }
 
-pub unsafe fn reset_frame_count(){
-    CURRENT_FRAME = 0;
+pub unsafe fn stop_counting(index:usize) {
+    SHOULD_COUNT[index] =  false;
 }
 
-pub unsafe fn get_frame_count() -> u32 {
-    CURRENT_FRAME
+pub unsafe fn reset_frame_count(index:usize) {
+    COUNTERS[index] = 0;
 }
 
-pub unsafe fn tick(){
-    if SHOULD_COUNT{
-        CURRENT_FRAME += 1;
-        println!("Tick {}",CURRENT_FRAME);
+pub unsafe fn get_frame_count(index:usize) -> u32 {
+    COUNTERS[index]
+}
+
+pub unsafe fn tick() {
+    for (index, _frame) in COUNTERS.iter().enumerate() {
+        if !SHOULD_COUNT[index]{
+            continue;
+        }
+        COUNTERS[index] += 1;
+        println!("Tick {}", COUNTERS[index]);
     }
 }
 
@@ -36,7 +47,7 @@ pub unsafe fn get_command_flag_cat(
         return;
     }
 
-    if !once_per_frame(module_accessor, category){
+    if !once_per_frame(module_accessor, category) {
         return;
     }
 

--- a/src/training/mod.rs
+++ b/src/training/mod.rs
@@ -9,6 +9,7 @@ pub mod shield;
 pub mod tech;
 
 pub mod combo;
+mod frame_counter;
 mod ledge;
 mod left_stick;
 mod mash;
@@ -44,6 +45,7 @@ pub unsafe fn handle_get_command_flag_cat(
 
     let mut flag = original!()(module_accessor, category);
 
+    frame_counter::get_command_flag_cat(module_accessor, category);
     combo::get_command_flag_cat(module_accessor, category);
 
     // bool replace;

--- a/src/training/mod.rs
+++ b/src/training/mod.rs
@@ -224,6 +224,8 @@ pub fn training_mods() {
         get_stick_y,
     );
 
+    combo::init();
+
     // // Input recorder
     // SaltySD_function_replace_sym(
     //     "_ZN3app8lua_bind31ControlModule__get_stick_x_implEPNS_26BattleObjectModuleAccessorE",


### PR DESCRIPTION
- Added enum for fighter ids
- Moved frame counting to separate module
- Added util function for running once per frame
- Updated frame advantage counter
    - Now starts counting when the player starts a move
    - Now allows tracking whiff frame data
    - Crouching moves are still a few frames off