### PR TITLE
Followups

### DIFF
--- a/src/common/consts.rs
+++ b/src/common/consts.rs
@@ -112,21 +112,6 @@ impl From<i32> for Attack {
     }
 }
 
-impl Attack {
-    pub fn into_attack_air_kind(&self) -> Option<i32> {
-        use Attack::*;
-
-        Some(match self {
-            Nair => *FIGHTER_COMMAND_ATTACK_AIR_KIND_N,
-            Fair => *FIGHTER_COMMAND_ATTACK_AIR_KIND_F,
-            Bair => *FIGHTER_COMMAND_ATTACK_AIR_KIND_B,
-            Dair => *FIGHTER_COMMAND_ATTACK_AIR_KIND_LW,
-            UpAir => *FIGHTER_COMMAND_ATTACK_AIR_KIND_HI,
-            _ => return None,
-        })
-    }
-}
-
 // Ledge Option
 #[repr(i32)]
 #[derive(Debug, Copy, Clone, PartialEq)]
@@ -271,7 +256,7 @@ pub enum OnOff {
 #[repr(i32)]
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Action {
-    None = 0,
+    Nothing = 0,
     Airdodge = 1,
     Jump = 2,
     Spotdodge = 3,
@@ -294,6 +279,22 @@ pub enum Action {
     Ftilt = 20,
     Utilt = 21,
     Dtilt = 22,
+    Shield = 99,
+}
+
+impl Action {
+    pub fn into_attack_air_kind(&self) -> Option<i32> {
+        use Action::*;
+
+        Some(match self {
+            Nair => *FIGHTER_COMMAND_ATTACK_AIR_KIND_N,
+            Fair => *FIGHTER_COMMAND_ATTACK_AIR_KIND_F,
+            Bair => *FIGHTER_COMMAND_ATTACK_AIR_KIND_B,
+            Dair => *FIGHTER_COMMAND_ATTACK_AIR_KIND_LW,
+            UpAir => *FIGHTER_COMMAND_ATTACK_AIR_KIND_HI,
+            _ => return None,
+        })
+    }
 }
 
 // To satisfy the unused warning
@@ -302,7 +303,7 @@ impl From<i32> for Action {
         use Action::*;
 
         match x {
-            0 => None,
+            0 => Nothing,
             1 => Airdodge,
             2 => Jump,
             3 => Spotdodge,
@@ -325,7 +326,8 @@ impl From<i32> for Action {
             20 => Ftilt,
             21 => Utilt,
             22 => Dtilt,
-            _ => None,
+            99 => Action::Shield,
+            _ => Nothing,
         }
     }
 }

--- a/src/common/consts.rs
+++ b/src/common/consts.rs
@@ -268,12 +268,75 @@ pub enum OnOff {
     On = 1,
 }
 
+#[repr(i32)]
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum Action {
+    None = 0,
+    Airdodge = 1,
+    Jump = 2,
+    Spotdodge = 3,
+    RollForward = 4,
+    RollBack = 5,
+    Nair = 6,
+    Fair = 7,
+    Bair = 8,
+    UpAir = 9,
+    Dair = 10,
+    NeutralB = 11,
+    SideB = 12,
+    UpB = 13,
+    DownB = 14,
+    UpSmash = 15,
+    FSmash = 16,
+    DSmash = 17,
+    Grab = 18,
+    Jab = 19,
+    Ftilt = 20,
+    Utilt = 21,
+    Dtilt = 22,
+}
+
+// To satisfy the unused warning
+impl From<i32> for Action {
+    fn from(x: i32) -> Self {
+        use Action::*;
+
+        match x {
+            0 => None,
+            1 => Airdodge,
+            2 => Jump,
+            3 => Spotdodge,
+            4 => RollForward,
+            5 => RollBack,
+            6 => Nair,
+            7 => Fair,
+            8 => Bair,
+            9 => UpAir,
+            10 => Dair,
+            11 => NeutralB,
+            12 => SideB,
+            13 => UpB,
+            14 => DownB,
+            15 => UpSmash,
+            16 => FSmash,
+            17 => DSmash,
+            18 => Grab,
+            19 => Jab,
+            20 => Ftilt,
+            21 => Utilt,
+            22 => Dtilt,
+            _ => None,
+        }
+    }
+}
+
 #[repr(C)]
 pub struct TrainingModpackMenu {
     pub hitbox_vis: HitboxVisualization,
     pub di_state: Direction,
     pub left_stick: Direction, // Currently only used for air dodge direction
     pub mash_attack_state: Attack,
+    pub follow_up: Action,
     pub ledge_state: LedgeOption,
     pub tech_state: TechOption,
     pub mash_state: Mash,

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -9,6 +9,7 @@ pub static mut MENU_STRUCT: consts::TrainingModpackMenu = consts::TrainingModpac
     di_state: Direction::None,
     left_stick: Direction::None,
     mash_attack_state: Attack::Nair,
+    follow_up: Action::None,
     ledge_state: LedgeOption::Random,
     tech_state: TechOption::Random,
     mash_state: Mash::None,

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -9,7 +9,7 @@ pub static mut MENU_STRUCT: consts::TrainingModpackMenu = consts::TrainingModpac
     di_state: Direction::None,
     left_stick: Direction::None,
     mash_attack_state: Attack::Nair,
-    follow_up: Action::None,
+    follow_up: Action::Nothing,
     ledge_state: LedgeOption::Random,
     tech_state: TechOption::Random,
     mash_state: Mash::None,

--- a/src/training/ledge.rs
+++ b/src/training/ledge.rs
@@ -40,7 +40,12 @@ pub unsafe fn force_option(module_accessor: &mut app::BattleObjectModuleAccessor
         status = new_status;
     }
 
-    mash::perform_defensive_option();
+    match ledge_case {
+        LedgeOption::Jump => {
+            mash::buffer_menu_mash(module_accessor);
+        }
+        _ => mash::perform_defensive_option(),
+    }
 
     StatusModule::change_status_request_from_script(module_accessor, status, true);
 }

--- a/src/training/mash.rs
+++ b/src/training/mash.rs
@@ -107,28 +107,13 @@ unsafe fn check_buffer(module_accessor: &mut app::BattleObjectModuleAccessor) {
         return;
     }
 
-    let mut mash = MENU.mash_state;
-
-    if mash == Mash::Random {
-        let mut random_cmds = vec![Mash::Jump, Mash::Attack];
-
-        if is_airborne(module_accessor) {
-            random_cmds.push(Mash::Airdodge);
-        }
-
-        if is_grounded(module_accessor) {
-            random_cmds.push(Mash::RollBack);
-            random_cmds.push(Mash::RollForward);
-            random_cmds.push(Mash::Spotdodge);
-        }
-
-        let random_cmd_index =
-            app::sv_math::rand(hash40("fighter"), random_cmds.len() as i32) as usize;
-
-        mash = random_cmds[random_cmd_index];
+    if MENU.mash_state == Mash::Random {
+        let action = get_random_action(module_accessor);
+        buffer_action(action);
+        return;
     }
 
-    let action = mash_to_action(mash);
+    let action = mash_to_action(MENU.mash_state);
     buffer_action(action);
 }
 
@@ -144,6 +129,26 @@ pub fn mash_to_action(mash: Mash) -> Action {
         Mash::Shield => Shield,
         Mash::Attack => unsafe { attack_to_action(MENU.mash_attack_state) },
         _ => Nothing,
+    }
+}
+
+pub fn get_random_action(module_accessor: &mut app::BattleObjectModuleAccessor) -> Action {
+    let mut random_cmds = vec![Mash::Jump, Mash::Attack];
+    unsafe {
+        if is_airborne(module_accessor) {
+            random_cmds.push(Mash::Airdodge);
+        }
+
+        if is_grounded(module_accessor) {
+            random_cmds.push(Mash::RollBack);
+            random_cmds.push(Mash::RollForward);
+            random_cmds.push(Mash::Spotdodge);
+        }
+
+        let random_cmd_index =
+            app::sv_math::rand(hash40("fighter"), random_cmds.len() as i32) as usize;
+
+        mash_to_action(random_cmds[random_cmd_index])
     }
 }
 

--- a/src/training/mash.rs
+++ b/src/training/mash.rs
@@ -231,11 +231,6 @@ unsafe fn perform_action(module_accessor: &mut app::BattleObjectModuleAccessor) 
             Doesn't actually cause the shield, but will clear the buffer once shield is possible.
             Shield hold is performed trough shield::should_hold_shield
             */
-            // return get_flag(
-            //     module_accessor,
-            //     *FIGHTER_STATUS_KIND_GUARD_ON,
-            //     *FIGHTER_PAD_CMD_CAT1_FLAG_AIR_ESCAPE,
-            // );
             return get_flag(
                 module_accessor,
                 *FIGHTER_STATUS_KIND_GUARD_ON,

--- a/src/training/mash.rs
+++ b/src/training/mash.rs
@@ -357,7 +357,7 @@ unsafe fn get_aerial_flag(
      */
     match action {
         Nair | Fair | Bair | UpAir | Dair => {
-            action_flag = *FIGHTER_COMMAND_ATTACK_AIR_KIND_N;
+            action_flag = *FIGHTER_PAD_CMD_CAT1_FLAG_ATTACK_N;
         }
         _ => {
             action_flag = 0;

--- a/src/training/mash.rs
+++ b/src/training/mash.rs
@@ -352,28 +352,11 @@ unsafe fn get_aerial_flag(
     use Action::*;
 
     /*
-     * For some reason the game doesn't trigger the aerials through the flags correctly.
-     * So we always trigger nair and change it later into the correct aerial
+     * We always trigger attack and change it later into the correct aerial
      * @see get_attack_air_kind()
      */
     match action {
-        Nair => {
-            action_flag = *FIGHTER_COMMAND_ATTACK_AIR_KIND_N;
-        }
-        Fair => {
-            // action_flag = *FIGHTER_COMMAND_ATTACK_AIR_KIND_F;
-            action_flag = *FIGHTER_COMMAND_ATTACK_AIR_KIND_N;
-        }
-        Bair => {
-            // action_flag = *FIGHTER_COMMAND_ATTACK_AIR_KIND_B;
-            action_flag = *FIGHTER_COMMAND_ATTACK_AIR_KIND_N;
-        }
-        UpAir => {
-            // action_flag = *FIGHTER_COMMAND_ATTACK_AIR_KIND_HI;
-            action_flag = *FIGHTER_COMMAND_ATTACK_AIR_KIND_N;
-        }
-        Dair => {
-            // action_flag = *FIGHTER_COMMAND_ATTACK_AIR_KIND_LW;
+        Nair | Fair | Bair | UpAir | Dair => {
             action_flag = *FIGHTER_COMMAND_ATTACK_AIR_KIND_N;
         }
         _ => {

--- a/src/training/mash.rs
+++ b/src/training/mash.rs
@@ -18,11 +18,6 @@ pub fn buffer_action(action: Action) {
 
     unsafe {
         QUEUE.insert(0, action);
-
-        if shield::is_aerial(action) {
-            set_aerial(action);
-        }
-
         buffer_follow_up();
     }
 }
@@ -339,7 +334,7 @@ unsafe fn get_aerial_flag(
 
     // If we are grounded we also need to jump
     if is_grounded(module_accessor) {
-        flag += *FIGHTER_PAD_CMD_CAT1_FLAG_JUMP_BUTTON;
+        flag |= *FIGHTER_PAD_CMD_CAT1_FLAG_JUMP_BUTTON;
 
         // Delay attack until we are airborne to get a full hop
         if MENU.full_hop == OnOff::On {
@@ -356,30 +351,37 @@ unsafe fn get_aerial_flag(
     let action_flag: i32;
     use Action::*;
 
+    /*
+     * For some reason the game doesn't trigger the aerials through the flags correctly.
+     * So we always trigger nair and change it later into the correct aerial
+     * @see get_attack_air_kind()
+     */
     match action {
         Nair => {
             action_flag = *FIGHTER_COMMAND_ATTACK_AIR_KIND_N;
         }
         Fair => {
-            // For some reason the game doesn't trigger the fair correctly
             // action_flag = *FIGHTER_COMMAND_ATTACK_AIR_KIND_F;
             action_flag = *FIGHTER_COMMAND_ATTACK_AIR_KIND_N;
         }
         Bair => {
-            action_flag = *FIGHTER_COMMAND_ATTACK_AIR_KIND_B;
+            // action_flag = *FIGHTER_COMMAND_ATTACK_AIR_KIND_B;
+            action_flag = *FIGHTER_COMMAND_ATTACK_AIR_KIND_N;
         }
         UpAir => {
-            // For some reason the game doesn't trigger the uair correctly
             // action_flag = *FIGHTER_COMMAND_ATTACK_AIR_KIND_HI;
             action_flag = *FIGHTER_COMMAND_ATTACK_AIR_KIND_N;
         }
         Dair => {
-            action_flag = *FIGHTER_COMMAND_ATTACK_AIR_KIND_LW;
+            // action_flag = *FIGHTER_COMMAND_ATTACK_AIR_KIND_LW;
+            action_flag = *FIGHTER_COMMAND_ATTACK_AIR_KIND_N;
         }
         _ => {
             action_flag = 0;
         }
     }
+
+    set_aerial(action);
 
     flag |= get_flag(module_accessor, status, action_flag);
 

--- a/src/training/mash.rs
+++ b/src/training/mash.rs
@@ -108,17 +108,24 @@ unsafe fn check_buffer(module_accessor: &mut app::BattleObjectModuleAccessor) {
         return;
     }
 
-    if MENU.mash_state == Mash::Random {
-        let action = get_random_action(module_accessor);
-        buffer_action(action);
-        return;
-    }
-
-    let action = mash_to_action(MENU.mash_state);
-    buffer_action(action);
+    buffer_menu_mash(module_accessor);
 }
 
 // Temp Translation
+pub fn buffer_menu_mash(module_accessor: &mut app::BattleObjectModuleAccessor) -> Action {
+    unsafe {
+        let action;
+        if MENU.mash_state == Mash::Random {
+            action = get_random_action(module_accessor);
+        } else {
+            action = mash_to_action(MENU.mash_state);
+        }
+        buffer_action(action);
+
+        action
+    }
+}
+
 pub fn mash_to_action(mash: Mash) -> Action {
     use Action::*;
     match mash {
@@ -133,7 +140,7 @@ pub fn mash_to_action(mash: Mash) -> Action {
     }
 }
 
-pub fn get_random_action(module_accessor: &mut app::BattleObjectModuleAccessor) -> Action {
+fn get_random_action(module_accessor: &mut app::BattleObjectModuleAccessor) -> Action {
     let mut random_cmds = vec![Mash::Jump, Mash::Attack];
     unsafe {
         if is_airborne(module_accessor) {

--- a/src/training/mash.rs
+++ b/src/training/mash.rs
@@ -65,7 +65,6 @@ pub fn set_aerial(attack: Action) {
 
     unsafe {
         CURRENT_AERIAL = attack;
-        println!("Setting Attack {}", attack as i32);
     }
 }
 
@@ -411,7 +410,6 @@ unsafe fn get_flag(
 pub unsafe fn perform_defensive_option() {
     reset();
 
-    let mut suspend_shield = true;
     let action;
 
     match MENU.defensive_state {

--- a/src/training/shield.rs
+++ b/src/training/shield.rs
@@ -132,7 +132,7 @@ pub unsafe fn get_param_float(
     None
 }
 
-pub unsafe fn should_hold_shield(module_accessor: &mut app::BattleObjectModuleAccessor) -> bool {
+pub unsafe fn should_hold_shield() -> bool {
     // Mash shield
     if mash::get_current_buffer() == Mash::Shield {
         return true;
@@ -143,26 +143,7 @@ pub unsafe fn should_hold_shield(module_accessor: &mut app::BattleObjectModuleAc
         return false;
     }
 
-    // Hold shield while OOS is not allowed
-    if !allow_oos() {
-        return true;
-    }
-
-    if !was_in_shieldstun(module_accessor) {
-        return true;
-    }
-
-    match mash::get_current_buffer() {
-        Mash::Attack => {} // Handle attack below
-        // If we are not mashing attack then we will always hold shield
-        _ => return true,
-    }
-
-    // We will hold shield if we are in shieldstun and our attack can be performed OOS
-    match mash::get_current_attack() {
-        Attack::Grab => return true, // Grab has 4 extra shield frames
-        _ => return false,
-    }
+    true
 }
 
 #[skyline::hook(replace = smash::lua2cpp::L2CFighterCommon_sub_guard_cont)]
@@ -376,7 +357,7 @@ unsafe fn should_return_none_in_check_button(
         return true;
     }
 
-    if !should_hold_shield(module_accessor) {
+    if !should_hold_shield() {
         return true;
     }
 

--- a/src/training/shield.rs
+++ b/src/training/shield.rs
@@ -179,12 +179,18 @@ unsafe fn mod_handle_sub_guard_cont(fighter: &mut L2CFighterCommon) {
         return;
     }
 
+    let action ;
+    if MENU.mash_state == Mash::Random {
+        action = mash::get_random_action(module_accessor);
+    }
+    else{
+        action = mash::mash_to_action(MENU.mash_state);
+    }
+    mash::buffer_action(action);
+
     if handle_escape_option(fighter, module_accessor) {
         return;
     }
-
-    let action = mash::mash_to_action(MENU.mash_state);
-    mash::buffer_action(action);
 
     if needs_oos_handling_drop_shield() {
         return;
@@ -256,20 +262,20 @@ unsafe fn handle_escape_option(
         return false;
     }
 
-    match MENU.mash_state {
-        Mash::Spotdodge => {
+    match mash::get_current_buffer() {
+        Action::Spotdodge => {
             fighter
                 .fighter_base
                 .change_status(FIGHTER_STATUS_KIND_ESCAPE.as_lua_int(), LUA_TRUE);
             return true;
         }
-        Mash::RollForward => {
+        Action::RollForward => {
             fighter
                 .fighter_base
                 .change_status(FIGHTER_STATUS_KIND_ESCAPE_F.as_lua_int(), LUA_TRUE);
             return true;
         }
-        Mash::RollBack => {
+        Action::RollBack => {
             fighter
                 .fighter_base
                 .change_status(FIGHTER_STATUS_KIND_ESCAPE_B.as_lua_int(), LUA_TRUE);
@@ -285,7 +291,7 @@ unsafe fn handle_escape_option(
 fn needs_oos_handling_drop_shield() -> bool {
     let action = mash::get_current_buffer();
 
-    if action ==Action::Jump {
+    if action == Action::Jump {
         return true;
     }
 

--- a/src/training/shield.rs
+++ b/src/training/shield.rs
@@ -134,7 +134,7 @@ pub unsafe fn get_param_float(
 
 pub unsafe fn should_hold_shield() -> bool {
     // Mash shield
-    if mash::get_current_buffer() == Mash::Shield {
+    if mash::get_current_buffer() == Action::Shield {
         return true;
     }
 
@@ -175,7 +175,7 @@ unsafe fn mod_handle_sub_guard_cont(fighter: &mut L2CFighterCommon) {
         return;
     }
 
-    if frame_counter::should_delay(MENU.reaction_time, REACTION_INDEX){
+    if frame_counter::should_delay(MENU.reaction_time, REACTION_INDEX) {
         return;
     }
 
@@ -183,25 +183,21 @@ unsafe fn mod_handle_sub_guard_cont(fighter: &mut L2CFighterCommon) {
         return;
     }
 
-    mash::buffer_action(MENU.mash_state);
-    mash::set_attack(MENU.mash_attack_state);
+    let action = mash::mash_to_action(MENU.mash_state);
+    mash::buffer_action(action);
 
     if needs_oos_handling_drop_shield() {
         return;
     }
 
     // Set shield suspension frames
-    match MENU.mash_state {
-        Mash::Attack => match MENU.mash_attack_state {
-            Attack::UpSmash => {}
-            Attack::Grab => {}
-            _ => {
-                // Force shield drop
-                suspend_shield(15);
-            }
-        },
-
-        _ => {}
+    match action {
+        Action::UpSmash => {}
+        Action::Grab => {}
+        _ => {
+            // Force shield drop
+            suspend_shield(15);
+        }
     }
 }
 
@@ -287,31 +283,30 @@ unsafe fn handle_escape_option(
  * Needed to allow these attacks to work OOS
  */
 fn needs_oos_handling_drop_shield() -> bool {
-    match mash::get_current_buffer() {
-        Mash::Jump => return true,
-        Mash::Attack => {
-            let attack = mash::get_current_attack();
-            if is_aerial(attack) {
-                return true;
-            }
+    let action = mash::get_current_buffer();
 
-            if attack == Attack::UpB {
-                return true;
-            }
-        }
-        _ => {}
+    if action ==Action::Jump {
+        return true;
+    }
+
+    if is_aerial(action) {
+        return true;
+    }
+
+    if action == Action::UpB {
+        return true;
     }
 
     false
 }
 
-fn is_aerial(attack: Attack) -> bool {
-    match attack {
-        Attack::Nair => return true,
-        Attack::Fair => return true,
-        Attack::Bair => return true,
-        Attack::UpAir => return true,
-        Attack::Dair => return true,
+pub fn is_aerial(action: Action) -> bool {
+    match action {
+        Action::Nair => return true,
+        Action::Fair => return true,
+        Action::Bair => return true,
+        Action::UpAir => return true,
+        Action::Dair => return true,
         _ => return false,
     }
 }

--- a/src/training/shield.rs
+++ b/src/training/shield.rs
@@ -182,13 +182,7 @@ unsafe fn mod_handle_sub_guard_cont(fighter: &mut L2CFighterCommon) {
         return;
     }
 
-    let action;
-    if MENU.mash_state == Mash::Random {
-        action = mash::get_random_action(module_accessor);
-    } else {
-        action = mash::mash_to_action(MENU.mash_state);
-    }
-    mash::buffer_action(action);
+    let action = mash::buffer_menu_mash(module_accessor);
 
     if handle_escape_option(fighter, module_accessor) {
         return;


### PR DESCRIPTION
- Refactored mash handling
    - Now uses a queue
- Added mash follow ups  
- Added action enum
    - Replaces mash/attack enum wherever possible
- Updated shield suspension
    - No longer tied to a specific frame count, instead resetting when the mash buffer is reset

Known issues:

- Cannot follow up with the same action
- Cannot follow up an aerial with a different aerial
