### PR TITLE
Fix Aerials

### DIFF
--- a/src/training/mash.rs
+++ b/src/training/mash.rs
@@ -8,6 +8,7 @@ use crate::training::shield;
 use smash::app::{self, lua_bind::*};
 use smash::lib::lua_const::*;
 
+static mut CURRENT_AERIAL: Action = Action::NAIR;
 static mut QUEUE: Vec<Action> = vec![];
 
 static mut FALLING_AERIAL: bool = false;
@@ -71,6 +72,10 @@ pub fn set_aerial(attack: Action) {
     if !shield::is_aerial(attack) {
         return;
     }
+
+    unsafe {
+        CURRENT_AERIAL = attack;
+    }
 }
 
 pub unsafe fn get_attack_air_kind(
@@ -84,7 +89,7 @@ pub unsafe fn get_attack_air_kind(
         return None;
     }
 
-    get_current_buffer().into_attack_air_kind()
+    CURRENT_AERIAL.into_attack_air_kind()
 }
 
 pub unsafe fn get_command_flag_cat(

--- a/src/training/mash.rs
+++ b/src/training/mash.rs
@@ -69,10 +69,6 @@ pub fn full_reset(){
 }
 
 pub fn set_aerial(attack: Action) {
-    if !shield::is_aerial(attack) {
-        return;
-    }
-
     unsafe {
         CURRENT_AERIAL = attack;
     }


### PR DESCRIPTION
Revert 4cc6654 => was causing NAir, unless a followup was selected

Removed shield::is_aerial check => Non Aerials will just return None in into_attack_air_kind()