### PR TITLE
Reduce SDI Pulses

### DIFF
--- a/src/training/sdi.rs
+++ b/src/training/sdi.rs
@@ -112,7 +112,7 @@ fn mod_check_hit_stop_delay_command(
     }
 
     unsafe {
-        COUNTER = (COUNTER + 1) % 4;
+        COUNTER = (COUNTER + 1) % 8;
     }
 
     unsafe {


### PR DESCRIPTION
Reduced SDI to every 8 frames to match the stock "CPU Shuffling: A lot"  option