### PR TITLE
Enable Dash Attack Again

### DIFF
--- a/TrainingModpackOverlay/include/taunt_toggles.hpp
+++ b/TrainingModpackOverlay/include/taunt_toggles.hpp
@@ -178,7 +178,7 @@ of hitstun or out of specific states.
     x(type,NeutralB,"Neutral B") x(type,SideB,"Side B") x(type,UpB,"Up B") x(type,DownB,"Down B") \
     x(type,FSmash,"Forward Smash") x(type,USmash,"Up Smash") x(type,DSmash,"Down Smash") \
     x(type,Jab,"Jab") x(type,FTilt,"Ftilt") x(type,UTilt,"Utilt") x(type,Dtilt,"Dtilt")  \
-    x(type,Grab,"Grab") x(type,Dash,"Dash") //x(type,DashAttack,"Dash Attack")
+    x(type,Grab,"Grab") x(type,Dash,"Dash") x(type,DashAttack,"Dash Attack")
 
 // clang-format on
 DEFINE_ENUM_CLASS(ActionFlag);
@@ -212,7 +212,7 @@ Make sure to turn them on/off
 before leaving the Character
 Select Screen.
 
-If you change this while in training, 
+If you change this while in training,
 make sure to restart training mode.
 )"""";
 

--- a/src/common/consts.rs
+++ b/src/common/consts.rs
@@ -232,8 +232,8 @@ bitflags! {
         const D_TILT  = 0x200000;
         const GRAB = 0x400000;
         // TODO: Make work
-        // const DASH_ATTACK = 0x400000;
         const DASH = 0x800000;
+        const DASH_ATTACK = 0x1000000;
     }
 }
 

--- a/src/training/mash.rs
+++ b/src/training/mash.rs
@@ -228,11 +228,7 @@ unsafe fn perform_action(module_accessor: &mut app::BattleObjectModuleAccessor) 
 
             try_change_status(module_accessor, dash_status, dash_transition);
 
-            return get_flag(
-                module_accessor,
-                *FIGHTER_STATUS_KIND_DASH,
-                0,
-            );
+            return get_flag(module_accessor, *FIGHTER_STATUS_KIND_DASH, 0);
         }
         _ => return get_attack_flag(module_accessor, action),
     }
@@ -333,25 +329,29 @@ unsafe fn get_attack_flag(
             command_flag = *FIGHTER_PAD_CMD_CAT1_FLAG_ATTACK_LW3;
             status = *FIGHTER_STATUS_KIND_ATTACK_LW3;
         }
-        // TODO: Make work
-        // Action::DASH_ATTACK => {
-        //     let current_status = StatusModule::status_kind(module_accessor);
-        //     let is_dashing = current_status == *FIGHTER_STATUS_KIND_DASH;
+        // TODO: Make it work, without being 1 frame late
+        Action::DASH_ATTACK => {
+            let current_status = StatusModule::status_kind(module_accessor);
+            let dash_status = *FIGHTER_STATUS_KIND_DASH;
+            let is_dashing = current_status == dash_status;
 
-        //     // Start Dash First
-        //     if !is_dashing {
-        //         let dash_transition = *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_DASH;
-        //         let dash_status = *FIGHTER_STATUS_KIND_DASH;
+            // Start Dash First
+            if !is_dashing {
+                let dash_transition = *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_DASH;
 
-        //         try_change_status(module_accessor, dash_status, dash_transition);
-        //         return 0;
-        //     }
+                try_change_status(module_accessor, dash_status, dash_transition);
+                return 0;
+            }
 
-        //     command_flag = *FIGHTER_PAD_CMD_CAT1_FLAG_ATTACK_N;
-        //     status = *FIGHTER_STATUS_KIND_ATTACK_DASH;
+            status = *FIGHTER_STATUS_KIND_ATTACK_DASH;
 
-        //     return get_flag(module_accessor, status, command_flag);
-        // }
+            let transition = *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_ATTACK_DASH;
+            try_change_status(module_accessor, status, transition);
+
+            //@TODO find out how to properly reset, since the status just returns FIGHTER_STATUS_KIND_DASH
+
+            return 0;
+        }
         _ => return 0,
     }
 


### PR DESCRIPTION
Known Issues:

Mash is not reset automatically for dash attack
Dash Attack skips the first dashing frame