### PR TITLE
Ledge hang

### DIFF
--- a/TrainingModpackOverlay/include/taunt_toggles.hpp
+++ b/TrainingModpackOverlay/include/taunt_toggles.hpp
@@ -87,7 +87,9 @@ position).
     x(type,Neutral,"Neutral") \
     x(type,Roll,"Roll") \
     x(type,Jump,"Jump") \
-    x(type,Attack,"Attack")
+    x(type,Attack,"Attack") \
+    x(type,Wait,"Wait")
+
 
 // clang-format on
 

--- a/src/common/consts.rs
+++ b/src/common/consts.rs
@@ -110,6 +110,7 @@ bitflags! {
         const ROLL = 0x2;
         const JUMP = 0x4;
         const ATTACK = 0x8;
+        const WAIT = 0x10;
     }
 }
 
@@ -120,6 +121,7 @@ impl LedgeOption {
             LedgeOption::ROLL => *FIGHTER_STATUS_KIND_CLIFF_ESCAPE,
             LedgeOption::JUMP => *FIGHTER_STATUS_KIND_CLIFF_JUMP1,
             LedgeOption::ATTACK => *FIGHTER_STATUS_KIND_CLIFF_ATTACK,
+            LedgeOption::WAIT => *FIGHTER_STATUS_KIND_CLIFF_WAIT,
             _ => return None,
         })
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,6 @@ fn nro_main(nro: &NroInfo<'_>) {
             training::directional_influence::handle_correct_damage_vector_common,
             training::sdi::process_hit_stop_delay,
             training::tech::handle_change_status,
-            training::ledge::is_enable_transition_term_replace,
         );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,8 @@ fn nro_main(nro: &NroInfo<'_>) {
             training::shield::handle_sub_guard_cont,
             training::directional_influence::handle_correct_damage_vector_common,
             training::sdi::process_hit_stop_delay,
-            training::tech::handle_change_status
+            training::tech::handle_change_status,
+            training::ledge::is_enable_transition_term_replace,
         );
     }
 }

--- a/src/training/ledge.rs
+++ b/src/training/ledge.rs
@@ -49,11 +49,15 @@ pub unsafe fn force_option(module_accessor: &mut app::BattleObjectModuleAccessor
         return;
     }
 
+    let ledge_case: LedgeOption = MENU.ledge_state.get_random();
+
+    if ledge_case == LedgeOption::WAIT {
+        LEDGE_DELAY = 900000;
+        return;
+    }
     reset_ledge_delay();
 
-    let ledge_case: LedgeOption = MENU.ledge_state.get_random();
     let status = ledge_case.into_status().unwrap_or(0);
-
     match ledge_case {
         LedgeOption::JUMP => {
             mash::buffer_menu_mash();

--- a/src/training/ledge.rs
+++ b/src/training/ledge.rs
@@ -91,18 +91,17 @@ pub unsafe fn force_option(module_accessor: &mut app::BattleObjectModuleAccessor
     StatusModule::change_status_request_from_script(module_accessor, status, true);
 }
 
-#[skyline::hook(replace = smash::app::lua_bind::WorkModule::is_enable_transition_term)]
-pub unsafe fn is_enable_transition_term_replace(
-    module_accessor: &mut app::BattleObjectModuleAccessor,
+pub unsafe fn is_enable_transition_term(
+    module_accessor: *mut app::BattleObjectModuleAccessor,
     term: i32,
-) -> bool {
+) -> Option<bool> {
     // Disallow cliff-climb if waiting on ledge per the current menu selection
     if LEDGE_CASE == LedgeOption::WAIT {
         if term == *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_CLIFF_CLIMB {
-            return false;
+            return Some(false);
         }
     }
-    original!()(module_accessor, term)
+    return None
 }
 
 pub fn get_command_flag_cat(module_accessor: &mut app::BattleObjectModuleAccessor) {

--- a/src/training/mod.rs
+++ b/src/training/mod.rs
@@ -11,6 +11,7 @@ pub mod directional_influence;
 pub mod sdi;
 pub mod shield;
 pub mod tech;
+pub mod ledge;
 
 mod air_dodge_direction;
 mod attack_angle;
@@ -20,7 +21,6 @@ mod frame_counter;
 mod full_hop;
 mod input_delay;
 mod input_record;
-mod ledge;
 mod mash;
 mod reset;
 mod save_states;

--- a/src/training/mod.rs
+++ b/src/training/mod.rs
@@ -255,8 +255,10 @@ pub unsafe fn handle_is_enable_transition_term(
     }
 
     combo::is_enable_transition_term(module_accessor, transition_term, ori);
-
-    ori
+    match ledge::is_enable_transition_term(module_accessor, transition_term) {
+        Some(r) => r,
+        None => ori,
+    }
 }
 
 extern "C" {


### PR DESCRIPTION
Fixes issue #88.

Adds a "Wait" option to the ledge options submenu. When this option is selected, the CPU will not take any ledge action and will hold on to ledge until it is knocked off or reaches the ledge timer.  