### PR TITLE
DI Indicator Fix and Left/Right Directions

### DIFF
--- a/src/common/consts.rs
+++ b/src/common/consts.rs
@@ -82,6 +82,8 @@ bitflags! {
         const DOWN = 0x40;
         const DOWN_OUT = 0x80;
         const NEUTRAL = 0x100;
+        const LEFT = 0x200;
+        const RIGHT = 0x400;
     }
 }
 
@@ -105,6 +107,8 @@ impl Direction {
             Direction::DOWN_IN => 6,
             Direction::DOWN => 7,
             Direction::DOWN_OUT => 8,
+            Direction::LEFT => 5,
+            Direction::RIGHT => 1,
             _ => 0,
         }
     }
@@ -119,6 +123,8 @@ impl Direction {
             Direction::DOWN_IN => "Down and In",
             Direction::DOWN => "Down",
             Direction::DOWN_OUT => "Down and Away",
+            Direction::LEFT => "Left",
+            Direction::RIGHT => "Right",
             _ => "",
         }.to_string()
     }

--- a/src/training/air_dodge_direction.rs
+++ b/src/training/air_dodge_direction.rs
@@ -1,5 +1,6 @@
 use crate::common::consts::*;
 use crate::common::*;
+use crate::training::directional_influence::should_reverse_angle;
 use core::f64::consts::PI;
 use smash::app::{self, lua_bind::*};
 use smash::lib::lua_const::*;
@@ -30,16 +31,20 @@ unsafe fn get_angle(module_accessor: &mut app::BattleObjectModuleAccessor) -> Op
 
     STICK_DIRECTION = MENU.air_dodge_dir.get_random();
     STICK_DIRECTION.into_angle().map(|angle| {
-        let launch_speed_x = KineticEnergy::get_speed_x(KineticModule::get_energy(
-            module_accessor,
-            *FIGHTER_KINETIC_ENERGY_ID_DAMAGE,
-        ) as *mut smash::app::KineticEnergy);
-    
-        // If we're launched left, reverse stick X
-        if launch_speed_x < 0.0 {
-            PI - angle
-        } else {
+        if !should_reverse_angle(&STICK_DIRECTION) {
+            // Direction is LEFT/RIGHT, so don't perform any adjustment
             angle
+        } else {
+            let launch_speed_x = KineticEnergy::get_speed_x(KineticModule::get_energy(
+                module_accessor,
+                *FIGHTER_KINETIC_ENERGY_ID_DAMAGE,
+            ) as *mut smash::app::KineticEnergy);
+            // If we're launched left, reverse stick X
+            if launch_speed_x < 0.0 {
+                PI - angle
+            } else {
+                angle
+            }
         }
     })
 }

--- a/src/training/directional_influence.rs
+++ b/src/training/directional_influence.rs
@@ -38,7 +38,7 @@ unsafe fn mod_handle_di(fighter: &mut L2CFighterCommon, _arg1: L2CValue) {
     let angle_tuple = DI_CASE
         .into_angle()
         .map_or((0.0, 0.0), |angle| {
-        let a = if should_reverse_angle() {
+        let a = if should_reverse_angle(&DI_CASE) {
             PI - angle
         } else {
             angle
@@ -50,12 +50,14 @@ unsafe fn mod_handle_di(fighter: &mut L2CFighterCommon, _arg1: L2CValue) {
     set_x_y(module_accessor, angle_tuple.0 as f32, angle_tuple.1 as f32);
 }
 
-pub fn should_reverse_angle() -> bool {
+pub fn should_reverse_angle(direction: &Direction) -> bool {
+
     let cpu_module_accessor = get_module_accessor(FighterId::CPU);
     let player_module_accessor = get_module_accessor(FighterId::Player);
     unsafe {
         PostureModule::pos_x(player_module_accessor)
             > PostureModule::pos_x(cpu_module_accessor)
+        && ![Direction::LEFT, Direction::RIGHT].contains(&direction)
     }
 }
 

--- a/src/training/directional_influence.rs
+++ b/src/training/directional_influence.rs
@@ -6,6 +6,9 @@ use smash::lib::lua_const::*;
 use smash::lib::L2CValue;
 use smash::lua2cpp::L2CFighterCommon;
 
+static mut DI_CASE: Direction = Direction::empty();
+
+
 #[skyline::hook(replace = smash::lua2cpp::L2CFighterCommon_FighterStatusDamage__correctDamageVectorCommon)]
 pub unsafe fn handle_correct_damage_vector_common(
     fighter: &mut L2CFighterCommon,
@@ -29,8 +32,10 @@ unsafe fn mod_handle_di(fighter: &mut L2CFighterCommon, _arg1: L2CValue) {
     }
 
     // Either left, right, or none
-    let angle_tuple = MENU.di_state
-        .get_random()
+    if MotionModule::frame(module_accessor) == 0.0 {
+        DI_CASE = MENU.di_state.get_random();
+    }
+    let angle_tuple = DI_CASE
         .into_angle()
         .map_or((0.0, 0.0), |angle| {
         let a = if should_reverse_angle() {

--- a/src/training/sdi.rs
+++ b/src/training/sdi.rs
@@ -50,7 +50,7 @@ fn mod_sdi_direction(fighter: &mut L2CFighterCommon) -> Option<f64> {
         }
 
         DIRECTION.into_angle().map(|angle| {
-            if directional_influence::should_reverse_angle() {
+            if directional_influence::should_reverse_angle(&DIRECTION) {
                 PI - angle
             } else {
                 angle


### PR DESCRIPTION
Resolves #205 and #181

DI is only rolled on the first frame of hitstun, preventing the indicator from wiggling as new DI directions are selected

Adds a left and right option to the Direction struct used in DI/SDI/Airdodge settings. The should_reverse_angle function now takes the Direction as an argument and uses that in its logic.