### PR TITLE
Instructions for Version Update from v2.6

### DIFF
--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -1,5 +1,6 @@
 pub mod consts;
 pub mod menu;
+pub mod release;
 
 use crate::common::consts::*;
 use smash::app::{self, lua_bind::*};

--- a/src/common/release.rs
+++ b/src/common/release.rs
@@ -1,0 +1,35 @@
+use std::fs;
+use std::io::Write;
+use skyline_web::DialogOk;
+
+const CURRENT_VERSION: &str = "3.0";
+const VERSION_FILE_PATH: &str = "sd:/TrainingModpack/version.txt";
+
+fn is_current_version(fpath: &str) -> bool {
+    // Create a blank version file if it doesn't exists
+    if fs::metadata(fpath).is_err() {
+        let _ = fs::File::create(fpath).expect("Could not create version file!");
+    }
+    let content = fs::read_to_string(fpath).unwrap_or("".to_string());
+    content == CURRENT_VERSION
+}
+
+fn record_current_version(fpath: &str) {
+    // Write the current version to the version file
+    let mut f = fs::File::create(fpath).unwrap();
+    write!(f, "{}", CURRENT_VERSION.to_owned()).expect("Could not record current version!");
+}
+
+pub fn version_check() {
+    // Display dialog box on launch if changing versions
+    if !is_current_version(VERSION_FILE_PATH) {
+        let mut msg: String = String::new();
+        msg.push_str("Thank you for installing version ");
+        msg.push_str(CURRENT_VERSION);
+        msg.push_str(" of the Training Modpack.\n\n");
+        msg.push_str("This version includes a change to the menu button combination, which is now SPECIAL+UPTAUNT.\n");
+        msg.push_str("Please refer to the Github page and the Discord server for a full list of recent changes.");
+        DialogOk::ok(&msg);
+        record_current_version(VERSION_FILE_PATH);
+    }
+}

--- a/src/common/release.rs
+++ b/src/common/release.rs
@@ -1,8 +1,7 @@
 use std::fs;
 use std::io::Write;
 use skyline_web::DialogOk;
-
-const CURRENT_VERSION: &str = "3.0";
+const CURRENT_VERSION: &'static str = env!("CARGO_PKG_VERSION");
 const VERSION_FILE_PATH: &str = "sd:/TrainingModpack/version.txt";
 
 fn is_current_version(fpath: &str) -> bool {

--- a/src/common/release.rs
+++ b/src/common/release.rs
@@ -23,13 +23,14 @@ fn record_current_version(fpath: &str) {
 pub fn version_check() {
     // Display dialog box on launch if changing versions
     if !is_current_version(VERSION_FILE_PATH) {
-        let mut msg: String = String::new();
-        msg.push_str("Thank you for installing version ");
-        msg.push_str(CURRENT_VERSION);
-        msg.push_str(" of the Training Modpack.\n\n");
-        msg.push_str("This version includes a change to the menu button combination, which is now SPECIAL+UPTAUNT.\n");
-        msg.push_str("Please refer to the Github page and the Discord server for a full list of recent changes.");
-        DialogOk::ok(&msg);
+        DialogOk::ok(
+            format!(
+                "Thank you for installing version {} of the Training Modpack.\n\n\
+                This version includes a change to the menu button combination, which is now SPECIAL+UPTAUNT.\n\
+                Please refer to the Github page and the Discord server for a full list of recent changes.",
+                CURRENT_VERSION
+            )
+        );
         record_current_version(VERSION_FILE_PATH);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ use crate::common::*;
 use training::combo::FRAME_ADVANTAGE;
 
 use skyline::libc::{c_void, fclose, fopen, fwrite, mkdir};
-use std::fs::remove_file;
+use std::fs;
 use skyline::nro::{self, NroInfo};
 
 use owo_colors::OwoColorize;
@@ -101,8 +101,11 @@ pub fn main() {
         }
     }
 
-    log!("Removing ovlTrainingModpack.ovl...");
-    remove_file("sd:/switch/.overlays/ovlTrainingModpack.ovl").expect("Could not remove ovlTrainingModpack.ovl");
+    let ovl_path = "sd:/switch/.overlays/ovlTrainingModpack.ovl";
+    if !fs::metadata(ovl_path).is_err() {
+        log!("Removing ovlTrainingModpack.ovl...");
+        fs::remove_file(ovl_path).unwrap();
+    }
 
     log!("Performing version check...");
     release::version_check();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@ use crate::common::*;
 use training::combo::FRAME_ADVANTAGE;
 
 use skyline::libc::{c_void, fclose, fopen, fwrite, mkdir};
+use std::fs::remove_file;
 use skyline::nro::{self, NroInfo};
 
 use owo_colors::OwoColorize;
@@ -99,4 +100,10 @@ pub fn main() {
             fclose(f);
         }
     }
+
+    log!("Removing ovlTrainingModpack.ovl...");
+    remove_file("sd:/switch/.overlays/ovlTrainingModpack.ovl").expect("Could not remove ovlTrainingModpack.ovl");
+
+    log!("Performing version check...");
+    release::version_check();
 }


### PR DESCRIPTION
This PR implements the following:

- Upon loading the modpack, display a dialog box with information about the new button combination if the software detects an upgrade or a fresh installation
- Most recent version information is stored in sd:/TrainingModpack/version.txt, which is compared to the current version to determine upgrade status
- Afterwards, write the current package version to version.txt so that the dialog box will not be displayed again
- If the Tesla overlay for the training modpack exists from a previous version, it is removed