### PR TITLE
Add ability to reset menus to the default

### DIFF
--- a/src/common/consts.rs
+++ b/src/common/consts.rs
@@ -685,10 +685,12 @@ impl to_url_param for i32 {
 // Macro to build the url parameter string
 macro_rules! url_params {
     (
+        #[derive($($trait_name:ident, )*)]
         pub struct $e:ident {
             $(pub $field_name:ident: $field_type:ty,)*
         }
     ) => {
+        #[derive($($trait_name, )*)]
         pub struct $e {
             $(pub $field_name: $field_type,)*
         }
@@ -710,6 +712,7 @@ macro_rules! url_params {
 
 #[repr(C)]
 url_params! {
+    #[derive(Clone, Copy, )]
     pub struct TrainingModpackMenu {
         pub hitbox_vis: OnOff,
         pub stage_hazards: OnOff,

--- a/src/common/menu.rs
+++ b/src/common/menu.rs
@@ -29,10 +29,10 @@ impl<'a> Toggle<'a> {
     pub fn new(title: &'a str, checked: bool, value: usize) -> Toggle<'a> {
         Toggle{
             title: title,
-            checked: if checked { "is-appear "} else { "is-hidden" },
+            checked: if checked { "is-appear"} else { "is-hidden" },
             index: 0,
             value,
-            default: if checked { "is-appear "} else { "is-hidden" },
+            default: if checked { "is-appear"} else { "is-hidden" },
         }
     }
 }
@@ -48,8 +48,8 @@ impl <'a>OnOffSelector<'a> {
     pub fn new(title: &'a str, checked: bool) -> OnOffSelector<'a> {
         OnOffSelector {
             title: title,
-            checked: if checked { "is-appear "} else { "is-hidden" },
-            default: if checked { "is-appear "} else { "is-hidden" },
+            checked: if checked { "is-appear"} else { "is-hidden" },
+            default: if checked { "is-appear"} else { "is-hidden" },
         }
     }
 }
@@ -77,10 +77,10 @@ impl<'a> SubMenu<'a> {
     pub fn add_toggle(&mut self, title: &'a str, checked: bool, value: usize, default: bool) {
         self.toggles.push(Toggle{
             title: title,
-            checked: if checked { "is-appear "} else { "is-hidden" },
+            checked: if checked { "is-appear"} else { "is-hidden" },
             index: self.max_idx() + 1,
             value,
-            default: if default { "is-appear "} else { "is-hidden" },
+            default: if default { "is-appear"} else { "is-hidden" },
         });
     }
 
@@ -98,8 +98,8 @@ impl<'a> SubMenu<'a> {
         // The HTML only supports a single onoffselector but the SubMenu stores it as a Vec
         self.onoffselector.push(OnOffSelector{
             title: title,
-            checked: if checked { "is-appear "} else { "is-hidden" },
-            default: if default { "is-appear "} else { "is-hidden" },
+            checked: if checked { "is-appear"} else { "is-hidden" },
+            default: if default { "is-appear"} else { "is-hidden" },
         });
     }
 }

--- a/src/common/menu.rs
+++ b/src/common/menu.rs
@@ -339,7 +339,8 @@ pub unsafe fn write_menu() {
         "Frame Advantage",
         "frame_advantage",
         MENU.frame_advantage as usize,
-        (MENU.frame_advantage as usize & OnOff::On as usize) != 0
+        (MENU.frame_advantage as usize & OnOff::On as usize) != 0,
+        DEFAULT_MENU.frame_advantage as usize,
     );
     overall_menu.add_sub_menu_onoff(
         "Mash In Neutral",

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -8,8 +8,7 @@ use smash::app::{self, lua_bind::*};
 use smash::hash40;
 use smash::lib::lua_const::*;
 
-
-pub static mut MENU: consts::TrainingModpackMenu = consts::TrainingModpackMenu {
+pub static DEFAULT_MENU: consts::TrainingModpackMenu = consts::TrainingModpackMenu {
     hitbox_vis: OnOff::On,
     stage_hazards: OnOff::Off,
     di_state: Direction::empty(),
@@ -40,6 +39,8 @@ pub static mut MENU: consts::TrainingModpackMenu = consts::TrainingModpackMenu {
     frame_advantage: OnOff::Off
 };
 
+
+pub static mut MENU: TrainingModpackMenu = DEFAULT_MENU;
 pub static mut FIGHTER_MANAGER_ADDR: usize = 0;
 pub static mut STAGE_MANAGER_ADDR: usize = 0;
 

--- a/src/templates/menu.html
+++ b/src/templates/menu.html
@@ -102,7 +102,7 @@
                     </div>
                 </a>
             </div>
-            <div class="header f-u-bold" style="flex-direction: column; justify-content: center;">
+            <div class="header f-u-bold" style="flex-direction: column; justify-content: center; align-items: end;">
                 <p class="header-desc">Reset Current Menu: &#xE0A2;</p>
                 <p class="header-desc">Reset All Menus: &#xE0A4;</p>
             </div>

--- a/src/templates/menu.html
+++ b/src/templates/menu.html
@@ -69,6 +69,14 @@
                 width: auto;
             }
 
+            /* */
+            .l-header {
+                display: flex;
+            }
+
+            .header-desc {
+                color: white;
+            }
         </style>
     </head>
 
@@ -86,13 +94,17 @@
                         Training
                         Modpack Menu</span></div>
             </div>
-            <div class="header">
+            <div class="header" style="flex-grow: 1;">
                 <a id="ret-button" tabindex="-1" class="header-decoration" href="javascript:goBackHook();" nx-se-disabled="">
                     <div class="ret-icon-wrapper">
                         <img class="ret-icon-shadow is-appear" ref="./help/img/icon/m_retnormal.svg" src="./help/img/icon/m_retnormal.svg">
                         <img class="ret-icon is-appear" ref="./help/img/icon/m_retnormal.svg" src="./help/img/icon/m_retnormal.svg">
                     </div>
                 </a>
+            </div>
+            <div class="header f-u-bold" style="flex-direction: column; justify-content: center;">
+                <p class="header-desc">Reset Current Menu: &#xE0A2;</p>
+                <p class="header-desc">Reset All Menus: &#xE0A4;</p>
             </div>
         </div>
         <br>

--- a/src/templates/menu.html
+++ b/src/templates/menu.html
@@ -69,11 +69,12 @@
                 width: auto;
             }
 
-            /* */
+            /* Handle alignment of items in the header */
             .l-header {
                 display: flex;
             }
 
+            /* Set menu description color */
             .header-desc {
                 color: white;
             }
@@ -367,6 +368,7 @@
             }
 
             function resetSubmenu() {
+                // Resets any open or focused submenus to the default values
                 $("[default*='is-appear']").each(function () {
                     if (isSubmenuFocused(this)) {
                         this.classList.add("is-appear");
@@ -382,6 +384,7 @@
             }
 
             function isSubmenuFocused(elem) {
+                // Return true if the element is in a submenu which is either focused or opened
                 return (
                     $(elem).closest(".l-qa").children(".is-opened, .is-focused").length
                     || $(elem).closest(".is-focused").length
@@ -389,6 +392,7 @@
             }
 
             function resetAllSubmenus() {
+                // Resets all submenus to the default values
                 if (confirm("Are you sure that you want to reset all menu settings to the default?")) {
                     $("[default*='is-appear']").each(function () {
                             this.classList.add("is-appear");

--- a/src/templates/menu.html
+++ b/src/templates/menu.html
@@ -3,7 +3,7 @@
 
     <head>
         <meta charset="UTF-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
         <title>Document</title>
         <link rel="stylesheet" href="./help/css/common.css" />
         <link rel="stylesheet" href="./help/css/qa.css" />
@@ -137,7 +137,7 @@
                                                 <div class="keyword-button-outer">
                                                     <a tabindex="{{index}}" class="flex-button keyword-button scuffle-thema" href="javascript:void(0)" onclick="clickToggle(this);" nx-se-disabled="">
                                                         <div class="button-icon-wrapper">
-                                                            <img class="button-icon toggle {{checked}}" ref="./check.svg" src="./check.svg">
+                                                            <img class="button-icon toggle {{checked}}" ref="./check.svg" src="./check.svg" default="{{default}}">
                                                         </div>
                                                         <div class="button-msg-wrapper">
                                                             <div class="keyword-message f-u-bold">
@@ -195,7 +195,7 @@
                                     <div id="question-{{id}}" class="question scuffle-thema">
                                         <div id="{{id}}" class="onoff">
                                             <img class="question-icon" style="z-index: 1;" ref="./{{id}}.svg" src="./{{id}}.svg" />
-                                            <div><img class="question-icon toggle {{checked}}" style="z-index: 2;" ref="./check.svg" src="./check.svg" /></div>
+                                            <div><img class="question-icon toggle {{checked}}" style="z-index: 2;" ref="./check.svg" src="./check.svg" default="{{default}}"/></div>
                                             <p class="keyword-message f-u-bold">
                                                 {{title}}
                                             </p>
@@ -226,6 +226,12 @@
         <script>
             if (isNx) {
                 window.nx.footer.setAssign('B', '', goBackHook, {
+                    se: ''
+                })
+                window.nx.footer.setAssign('X', '', resetSubmenu, {
+                    se: ''
+                })
+                window.nx.footer.setAssign('L', '', resetAllSubmenus, {
                     se: ''
                 })
             }
@@ -346,6 +352,41 @@
                         e.classList.add("is-hidden");
                     }
                 });
+            }
+
+            function resetSubmenu() {
+                $("[default*='is-appear']").each(function () {
+                    if (isSubmenuFocused(this)) {
+                        this.classList.add("is-appear");
+                        this.classList.remove("is-hidden");
+                    }
+                });
+                $("[default*='is-hidden']").each(function() {
+                    if (isSubmenuFocused(this)) {
+                        this.classList.remove("is-appear");
+                        this.classList.add("is-hidden");
+                    }
+                });
+            }
+
+            function isSubmenuFocused(elem) {
+                return (
+                    $(elem).closest(".l-qa").children(".is-opened, .is-focused").length
+                    || $(elem).closest(".is-focused").length
+                )
+            }
+
+            function resetAllSubmenus() {
+                if (confirm("Are you sure that you want to reset all menu settings to the default?")) {
+                    $("[default*='is-appear']").each(function () {
+                            this.classList.add("is-appear");
+                            this.classList.remove("is-hidden");
+                    });
+                    $("[default*='is-hidden']").each(function() {
+                            this.classList.remove("is-appear");
+                            this.classList.add("is-hidden");
+                    });
+                }
             }
         </script>
         <script>


### PR DESCRIPTION
This PR includes the following:

- Create a static DEFAULT_MENU struct with initial values and populate the MENU by cloning that
- Add a default field to menu component structs in menu.rs which specifies what the proper reset value is
- Add HTML attribute "default=is-appear" or "default=is-hidden" to menu setting elements
- Add JS functions which set the is-appear or is-hidden classes according to the defaults. Pressing X only resets open/focused submenus, and pressing L resets all submenus after a confirmation dialog
- Add reset button descriptions to the menu header