### PR TITLE
Restrict menu opening multiple times in rapid succession

### DIFF
--- a/src/training/mod.rs
+++ b/src/training/mod.rs
@@ -12,12 +12,12 @@ pub mod sdi;
 pub mod shield;
 pub mod tech;
 pub mod ledge;
+pub mod frame_counter;
 
 mod air_dodge_direction;
 mod attack_angle;
 mod character_specific;
 mod fast_fall;
-mod frame_counter;
 mod full_hop;
 mod input_delay;
 mod input_record;


### PR DESCRIPTION
This PR implements a frame counter for the menu, which prevents opening the menu within 5 frames of the last menu open. This has the aim of preventing the annoying bug where closing the menu with B can cause it to immediately reopen.