### PR TITLE
Fix outside_training_mode NRO

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -61,7 +61,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Build outside_training_mode NRO
       run: |
-        PATH=$PATH:/root/.cargo/bin:/opt/devkitpro/devkitA64/bin /root/.cargo/bin/cargo-skyline skyline build --release
+        PATH=$PATH:/root/.cargo/bin:/opt/devkitpro/devkitA64/bin /root/.cargo/bin/cargo-skyline skyline build --release --features outside_training_mode
       env:
         HOME: /root
     - name: Upload plugin (outside training mode) artifact


### PR DESCRIPTION
Latest outside_training_mode NRO doesn't seem to function any differently than the normal NRO file. Everything works as intended inside training mode, but outside of it e.g. Smash mode, nothing works (no hitboxes) and I'm also unable to open the menu.

I believe you just need to add back in "--features outside_training_mode" when you're building the outside_training_mode NRO and it should work as intended.