### PR TITLE
Configurable default menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ The timing of the CPU option can be influenced by the following settings:
 ## Menu Settings
 
 When multiple options are selected, one of the selected options will be chosen at random. Open / focused menus can be reset by pressing the `X` button. All menus can be reset to the default by pressing the `L` button.
+When in-game, the current menu selections can be set as the default by pressing the `SPECIAL+JUMP+Down Taunt` combination. This will change the defaults that are used for the in-menu reset.
 
 | Feature              | Description                                                                                 | Options                                                                                                           |
 |----------------------|---------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------|

--- a/README.md
+++ b/README.md
@@ -85,8 +85,8 @@ The timing of the CPU option can be influenced by the following settings:
 
 ## Menu Settings
 
-When multiple options are selected, one of the selected options will be chosen at random. Open / focused menus can be reset by pressing the `X` button. All menus can be reset to the default by pressing the `L` button.
-When in-game, the current menu selections can be set as the default by pressing the `SPECIAL+JUMP+Down Taunt` combination. This will change the defaults that are used for the in-menu reset.
+When multiple options are selected, one of the selected options will be chosen at random. Open / focused menus can be reset by pressing the `X` button. All menus can be reset to the default by pressing the `L` button. These defaults can be saved upon exiting the menu by pressing `R` when in-menu. Use this to make a preset that fits your personal training style.
+
 
 | Feature              | Description                                                                                 | Options                                                                                                           |
 |----------------------|---------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------|

--- a/src/common/menu.rs
+++ b/src/common/menu.rs
@@ -264,7 +264,7 @@ macro_rules! add_onoff_submenu {
     };
 }
 
-pub unsafe fn set_menu_from_url(mut menu: TrainingModpackMenu, s: &str) {
+pub fn set_menu_from_url(mut menu: TrainingModpackMenu, s: &str) -> TrainingModpackMenu {
     let base_url_len = "http://localhost/?".len();
     let total_len = s.len();
 
@@ -295,6 +295,7 @@ pub unsafe fn set_menu_from_url(mut menu: TrainingModpackMenu, s: &str) {
 
         menu.set(toggle, bits);
     }
+    menu
 }
 
 pub unsafe fn menu_condition(module_accessor: &mut smash::app::BattleObjectModuleAccessor) -> bool {
@@ -569,7 +570,7 @@ pub unsafe fn spawn_menu() {
         .unwrap();
 
     let last_url = page_response.get_last_url().unwrap();
-    set_menu_from_url(MENU, last_url);
+    MENU = set_menu_from_url(MENU, last_url);
 
     let menu_conf_path = "sd:/TrainingModpack/training_modpack_menu.conf";
     std::fs::write(menu_conf_path, last_url).expect("Failed to write menu conf file");
@@ -600,12 +601,12 @@ pub unsafe fn save_menu_defaults_condition(
 }
 
 pub unsafe fn save_menu_defaults() {
+    println!("Saving menu defaults...");
     let last_url = format!("{}{}", "http://localhost", MENU.to_url_params());
-    DEFAULT_MENU = MENU;
-    // If this doesn't work can also try
-    // set_menu_from_url(DEFAULT_MENU, &last_url);
+    DEFAULT_MENU = set_menu_from_url(DEFAULT_MENU, &last_url);
 
     let menu_defaults_conf_path = "sd:/TrainingModpack/training_modpack_menu_defaults.conf";
     std::fs::write(menu_defaults_conf_path, last_url)
         .expect("Failed to write default menu conf file");
+    write_menu();
 }

--- a/src/common/menu.rs
+++ b/src/common/menu.rs
@@ -5,6 +5,7 @@ use ramhorns::{Content, Template};
 use skyline::info::get_program_id;
 use skyline_web::{Background, BootDisplay, Webpage};
 use smash::lib::lua_const::*;
+use smash::phx::{Hash40, Vector3f};
 use std::fs;
 use std::path::Path;
 use strum::IntoEnumIterator;
@@ -609,4 +610,26 @@ pub unsafe fn save_menu_defaults() {
     std::fs::write(menu_defaults_conf_path, last_url)
         .expect("Failed to write default menu conf file");
     write_menu();
+
+    let zeros = Vector3f {
+        x: 0.0,
+        y: 0.0,
+        z: 0.0,
+    };
+    EffectModule::req_on_joint(
+        get_module_accessor(FighterId::Player),
+        Hash40::new("sys_hit_magic_s"),
+        Hash40::new("top"),
+        &zeros,
+        &zeros,
+        3.0,
+        &zeros,
+        &zeros,
+        true,
+        *EFFECT_SUB_ATTRIBUTE_NO_JOINT_SCALE as u32
+            | *EFFECT_SUB_ATTRIBUTE_FOLLOW as u32
+            | *EFFECT_SUB_ATTRIBUTE_CONCLUDE_STATUS as u32,
+        0,
+        0,
+    );
 }

--- a/src/common/menu.rs
+++ b/src/common/menu.rs
@@ -605,12 +605,13 @@ pub unsafe fn save_menu_defaults() {
     println!("Saving menu defaults...");
     let last_url = format!("{}{}", "http://localhost", MENU.to_url_params());
     DEFAULT_MENU = set_menu_from_url(DEFAULT_MENU, &last_url);
+    write_menu();
 
     let menu_defaults_conf_path = "sd:/TrainingModpack/training_modpack_menu_defaults.conf";
     std::fs::write(menu_defaults_conf_path, last_url)
         .expect("Failed to write default menu conf file");
-    write_menu();
 
+    // Generate visual effect
     let zeros = Vector3f {
         x: 0.0,
         y: 0.0,
@@ -622,7 +623,7 @@ pub unsafe fn save_menu_defaults() {
         Hash40::new("top"),
         &zeros,
         &zeros,
-        3.0,
+        1.0,
         &zeros,
         &zeros,
         true,

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -10,7 +10,7 @@ use smash::app::{self, lua_bind::*};
 use smash::hash40;
 use smash::lib::lua_const::*;
 
-pub static DEFAULT_MENU: consts::TrainingModpackMenu = consts::TrainingModpackMenu {
+pub static BASE_MENU: consts::TrainingModpackMenu = consts::TrainingModpackMenu {
     hitbox_vis: OnOff::On,
     stage_hazards: OnOff::Off,
     di_state: Direction::empty(),
@@ -42,7 +42,8 @@ pub static DEFAULT_MENU: consts::TrainingModpackMenu = consts::TrainingModpackMe
     save_state_enable: OnOff::On,
 };
 
-pub static mut MENU: TrainingModpackMenu = DEFAULT_MENU;
+pub static mut DEFAULT_MENU: TrainingModpackMenu = BASE_MENU;
+pub static mut MENU: TrainingModpackMenu = BASE_MENU;
 pub static mut FIGHTER_MANAGER_ADDR: usize = 0;
 pub static mut STAGE_MANAGER_ADDR: usize = 0;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,7 +92,23 @@ pub fn main() {
         log!("Loading previous menu from training_modpack_menu.conf...");
         let menu_conf = fs::read(menu_conf_path).unwrap();
         if menu_conf.starts_with(b"http://localhost") {
-            set_menu_from_url(std::str::from_utf8(&menu_conf).unwrap());
+            unsafe {
+                set_menu_from_url(MENU, std::str::from_utf8(&menu_conf).unwrap());
+            }
+        }
+    }
+
+    let menu_defaults_conf_path = "sd:/TrainingModpack/training_modpack_menu_defaults.conf";
+    if fs::metadata(menu_defaults_conf_path).is_ok() {
+        log!("Loading previous menu from training_modpack_menu.conf...");
+        let menu_defaults_conf = fs::read(menu_defaults_conf_path).unwrap();
+        if menu_defaults_conf.starts_with(b"http://localhost") {
+            unsafe {
+                set_menu_from_url(
+                    DEFAULT_MENU,
+                    std::str::from_utf8(&menu_defaults_conf).unwrap(),
+                );
+            }
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,28 +88,39 @@ pub fn main() {
     release::version_check();
 
     let menu_conf_path = "sd:/TrainingModpack/training_modpack_menu.conf";
+    log!("Checking for previous menu in training_modpack_menu.conf...");
     if fs::metadata(menu_conf_path).is_ok() {
-        log!("Loading previous menu from training_modpack_menu.conf...");
         let menu_conf = fs::read(menu_conf_path).unwrap();
         if menu_conf.starts_with(b"http://localhost") {
+            log!("Previous menu found, loading from training_modpack_menu.conf");
             unsafe {
-                set_menu_from_url(MENU, std::str::from_utf8(&menu_conf).unwrap());
+                MENU = set_menu_from_url(MENU, std::str::from_utf8(&menu_conf).unwrap());
             }
+        } else {
+            log!("Previous menu found but is invalid.");
         }
+    } else {
+        log!("No previous menu file found.");
     }
 
     let menu_defaults_conf_path = "sd:/TrainingModpack/training_modpack_menu_defaults.conf";
+    log!("Checking for previous menu defaults in training_modpack_menu_defaults.conf...");
     if fs::metadata(menu_defaults_conf_path).is_ok() {
-        log!("Loading previous menu from training_modpack_menu.conf...");
         let menu_defaults_conf = fs::read(menu_defaults_conf_path).unwrap();
         if menu_defaults_conf.starts_with(b"http://localhost") {
+            log!("Menu defaults found, loading from training_modpack_menu_defaults.conf");
             unsafe {
-                set_menu_from_url(
+                DEFAULT_MENU = set_menu_from_url(
                     DEFAULT_MENU,
                     std::str::from_utf8(&menu_defaults_conf).unwrap(),
                 );
+                crate::menu::write_menu();
             }
+        } else {
+            log!("Previous menu defaults found but are invalid.");
         }
+    } else {
+        log!("No previous menu defaults found.");
     }
 
     std::thread::spawn(|| loop {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@ extern crate num_derive;
 
 use crate::common::*;
 use crate::events::{Event, EVENT_QUEUE};
-use crate::menu::set_menu_from_url;
+use crate::menu::get_menu_from_url;
 
 use skyline::libc::mkdir;
 use skyline::nro::{self, NroInfo};
@@ -94,7 +94,7 @@ pub fn main() {
         if menu_conf.starts_with(b"http://localhost") {
             log!("Previous menu found, loading from training_modpack_menu.conf");
             unsafe {
-                MENU = set_menu_from_url(MENU, std::str::from_utf8(&menu_conf).unwrap());
+                MENU = get_menu_from_url(MENU, std::str::from_utf8(&menu_conf).unwrap());
             }
         } else {
             log!("Previous menu found but is invalid.");
@@ -110,7 +110,7 @@ pub fn main() {
         if menu_defaults_conf.starts_with(b"http://localhost") {
             log!("Menu defaults found, loading from training_modpack_menu_defaults.conf");
             unsafe {
-                DEFAULT_MENU = set_menu_from_url(
+                DEFAULT_MENU = get_menu_from_url(
                     DEFAULT_MENU,
                     std::str::from_utf8(&menu_defaults_conf).unwrap(),
                 );

--- a/src/templates/menu.html
+++ b/src/templates/menu.html
@@ -95,6 +95,7 @@
             .defaults-checkbox-container {
                 position: fixed;
                 right: 50px;
+                margin-top: 10px;
                 display: flex;
                 justify-content: center;
                 flex-direction: column;
@@ -106,15 +107,19 @@
                 left: -100vw;
             }
 
+            .checkbox-display {
+                margin: 10px 70px;
+            }
+
             /* Displayed Checkbox (unchecked) */
             .checkbox-display::after {
-                content: "&#xE14C;";
+                content: "\E14C";
                 color: white;
             }
 
             /* Displayed Checkbox (checked) */
             #saveDefaults:checked ~ .checkbox-display::after {
-                content: "&#xE14B;";
+                content: "\E14B";
             }
         </style>
     </head>

--- a/src/templates/menu.html
+++ b/src/templates/menu.html
@@ -90,6 +90,32 @@
                 position: fixed;
                 z-index: 10;
             }
+
+            /* Save Defaults Container */
+            .defaults-checkbox-container {
+                position: fixed;
+                right: 50px;
+                display: flex;
+                justify-content: center;
+                flex-direction: column;
+            }
+
+            /* Checkbox element (hidden) */
+            #saveDefaults {
+                position: absolute;
+                left: -100vw;
+            }
+
+            /* Displayed Checkbox (unchecked) */
+            .checkbox-display::after {
+                content: "&#xE14C;";
+                color: white;
+            }
+
+            /* Displayed Checkbox (checked) */
+            #saveDefaults:checked ~ .checkbox-display::after {
+                content: "&#xE14B;";
+            }
         </style>
     </head>
 
@@ -249,6 +275,11 @@
         {{/sub_menus}}
         <footer id="footer" class="footer l-footer f-u-bold">
             <p id="help-text" class="header-desc"></p>
+            <div class="defaults-checkbox-container">
+                <label class="header-desc" for="saveDefaults">Save defaults: &#xE0A5;</label>
+                <input type="checkbox" id="saveDefaults">
+                <div class="checkbox-display"></div>
+            </div>
         </footer>
         <script>
             if (isNx) {
@@ -259,6 +290,9 @@
                     se: ''
                 })
                 window.nx.footer.setAssign('L', '', resetAllSubmenus, {
+                    se: ''
+                })
+                window.nx.footer.setAssign('R', '', toggleSaveDefaults, {
                     se: ''
                 })
             }
@@ -273,11 +307,6 @@
                     disabledOtherLink()
 
                     playSound('cancel')
-
-                    fadeOutPage(function () {
-                        window.history.back()
-                    })
-
 
                     var url = "http://localhost/"
 
@@ -317,7 +346,16 @@
                         });
                     });
 
-                    location.href = url + "?" + decodeURIComponent($.param(settings));
+                    url += "?" + decodeURIComponent($.param(settings));
+                    if ($("#saveDefaults").prop("checked")) {
+                        url += "&save_defaults=1";
+                    }
+                    // console.log(url);
+                    location.href = url;
+
+                    fadeOutPage(function () {
+                        window.history.back()
+                    })
                 } else {
                     // Close any open submenus
                     $(".qa.is-opened").each(function () { openAnswer(this); });
@@ -425,6 +463,15 @@
             function setHelpText(text) {
                 // Modify the help text in the footer
                 $("#help-text").text(text);
+            }
+
+            function toggleSaveDefaults() {
+                // Change the status of the Save Defaults checkbox
+                var saveDefaultsCheckbox = $("#saveDefaults");
+                saveDefaultsCheckbox.prop(
+                    "checked",
+                    !saveDefaultsCheckbox.prop("checked")
+                );
             }
         </script>
         <script>

--- a/src/training/mod.rs
+++ b/src/training/mod.rs
@@ -100,6 +100,8 @@ fn once_per_frame_per_fighter(
     unsafe {
         if crate::common::menu::menu_condition(module_accessor) {
             crate::common::menu::spawn_menu();
+        } else if crate::common::menu::save_menu_defaults_condition(module_accessor) {
+            crate::common::menu::save_menu_defaults()
         }
 
         input_record::get_command_flag_cat(module_accessor);

--- a/src/training/mod.rs
+++ b/src/training/mod.rs
@@ -100,8 +100,6 @@ fn once_per_frame_per_fighter(
     unsafe {
         if crate::common::menu::menu_condition(module_accessor) {
             crate::common::menu::spawn_menu();
-        } else if crate::common::menu::save_menu_defaults_condition(module_accessor) {
-            crate::common::menu::save_menu_defaults()
         }
 
         input_record::get_command_flag_cat(module_accessor);


### PR DESCRIPTION
Allows the user to save the current menu as the new defaults, which are used when resetting the menu selections with L or with X.

The defaults are also saved in a config file to enable persistence when the game is closed.

The button combination to save the defaults is SPECIAL+JUMP+DOWNTAUNT.

Closes #279 