### PR TITLE
Bugfix: Ice Climbers savestates

### DIFF
--- a/src/common/menu.rs
+++ b/src/common/menu.rs
@@ -11,7 +11,7 @@ use std::path::Path;
 use strum::IntoEnumIterator;
 
 static mut FRAME_COUNTER_INDEX: usize = 0;
-const MENU_LOCKOUT_FRAMES: u32 = 5;
+const MENU_LOCKOUT_FRAMES: u32 = 15;
 
 pub fn init() {
     unsafe {

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -83,12 +83,15 @@ pub fn is_operation_cpu(module_accessor: &mut app::BattleObjectModuleAccessor) -
             return false;
         }
 
-        let entry_id_int =
-            WorkModule::get_int(module_accessor, *FIGHTER_INSTANCE_WORK_ID_INT_ENTRY_ID) as i32;
+        let entry_id_int = WorkModule::get_int(module_accessor, *FIGHTER_INSTANCE_WORK_ID_INT_ENTRY_ID) as i32;
+        
+        if entry_id_int == 0 {
+            return false;
+        }   
+        
         let entry_id = app::FighterEntryID(entry_id_int);
         let mgr = *(FIGHTER_MANAGER_ADDR as *mut *mut app::FighterManager);
-        let fighter_information =
-            FighterManager::get_fighter_information(mgr, entry_id) as *mut app::FighterInformation;
+        let fighter_information = FighterManager::get_fighter_information(mgr, entry_id) as *mut app::FighterInformation;
 
         FighterInformation::is_operation_cpu(fighter_information)
     }


### PR DESCRIPTION
Resolves issues with save states for the Ice Climbers. When loading a save state, Nana now correctly moves to Popo, adjusts her percent to the correct amount, and maintains the functionality of her moves (she was getting killed twice like PT used to, which had glaring side effects). They would also pull up the menu twice, so the menu lockout has been increased to prevent this (and should prevent other repeat pull ups as well).

Similar to the PT fix, there are some further considerations that could be made for the Ice Climbers. Nana steals Popo's percent and position from the save state, meaning having save states with them separated or set up for a separation isn't possible. Given how relatively not useful this is, it won't be a priority for a long while. Also, because Nana receives inputs 6 frames after Popo, she's guaranteed to flicker shield or airdodge if the player is controlling the Ice Climbers and loads a state, since loading a state only takes ~5 frames. This is again much too small of an issue to warrant delaying the fix, so I'll attempt to take care of it in the future if a solution becomes apparent.