### PR TITLE
Buffing

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ When multiple options are selected, one of the selected options will be chosen a
 | Throw Options        | Throw to be performed when a grab is landed                                                 | None, Forward Throw, Back Throw, Up Throw, Down Throw                                                             |
 | Throw Delay          | How many frames to delay the throw option                                                   | 0 to 150 frames (2.5 seconds) in increments of 5 frames                                                           |
 | Pummel Delay         | How many frames after a grab to wait before starting to pummel                              | 0 to 150 frames (2.5 seconds) in increments of 5 frames                                                           |
+| Buff Options         | Buffs to be applied to respective character when loading save states                        | Acceleratle, Oomph, Psyche Up, Bounce, Arsene, Deep Breathing, Limit Break, KO Punch, One-Winged Angel            |
 | Input Delay          | Frames to delay player inputs by                                                            | 0 to 10 frames (0.167 seconds)                                                                                    |
 | Save Damage          | Should save states retain player/CPU damage                                                 | Yes, No                                                                                                           |
 | Hitbox Visualization | Should hitboxes be displayed, hiding other visual effects                                   | Yes, No                                                                                                           |
@@ -144,6 +145,7 @@ SD Card Root
             │           ├── aerial_delay.svg
             │           ├── air_dodge_dir.svg
             │           ├── attack_angle.svg
+            │           ├── buff_state.svg
             │           ├── check.svg
             │           ├── defensive_state.svg
             │           ├── di_state.svg

--- a/src/common/consts.rs
+++ b/src/common/consts.rs
@@ -502,6 +502,56 @@ impl ThrowOption {
 
 extra_bitflag_impls! {ThrowOption}
 
+// Buff Option
+bitflags! {
+    pub struct BuffOption : u32
+    {
+        const ACCELERATLE = 0x1;
+        const OOMPH = 0x2;
+        const PSYCHE = 0x4;
+        const BOUNCE = 0x8;
+        const ARSENE = 0x10;
+        const BREATHING = 0x20;
+        const LIMIT = 0x40;
+        const KO = 0x80;
+        const WING = 0x100;
+    }
+}
+
+impl BuffOption {
+    pub fn into_int(self) -> Option<i32> {
+        Some(match self {
+            BuffOption::ACCELERATLE => *FIGHTER_BRAVE_SPECIAL_LW_COMMAND11_SPEED_UP,
+            BuffOption::OOMPH => *FIGHTER_BRAVE_SPECIAL_LW_COMMAND12_ATTACK_UP,
+            BuffOption::PSYCHE => *FIGHTER_BRAVE_SPECIAL_LW_COMMAND21_CHARGE,
+            BuffOption::BOUNCE => *FIGHTER_BRAVE_SPECIAL_LW_COMMAND13_REFLECT,
+            BuffOption::BREATHING => 1,
+            BuffOption::ARSENE => 1,
+            BuffOption::LIMIT => 1,
+            BuffOption::KO => 1,
+            BuffOption::WING => 1,
+            _ => return None,
+        })
+    }
+
+    fn as_str(self) -> Option<&'static str> {
+        Some(match self {
+            BuffOption::ACCELERATLE => "Acceleratle",
+            BuffOption::OOMPH => "Oomph",
+            BuffOption::PSYCHE => "Psyche Up",
+            BuffOption::BOUNCE => "Bounce",
+            BuffOption::BREATHING => "Deep Breathing",
+            BuffOption::ARSENE => "Arsene",
+            BuffOption::LIMIT => "Limit Break",
+            BuffOption::KO => "KO Punch",
+            BuffOption::WING => "One-Winged Angel",
+            _ => return None,
+        })
+    }
+}
+
+extra_bitflag_impls! {BuffOption}
+
 impl Delay {
     pub fn as_str(self) -> Option<&'static str> {
         Some(match self {
@@ -836,6 +886,7 @@ url_params! {
         pub throw_state: ThrowOption,
         pub throw_delay: MedDelay,
         pub pummel_delay: MedDelay,
+        pub buff_state: BuffOption,
     }
 }
 
@@ -886,6 +937,7 @@ impl TrainingModpackMenu {
             throw_state = ThrowOption::from_bits(val),
             throw_delay = MedDelay::from_bits(val),
             pummel_delay = MedDelay::from_bits(val),
+            buff_state = BuffOption::from_bits(val),
         );
     }
 }

--- a/src/common/consts.rs
+++ b/src/common/consts.rs
@@ -538,8 +538,8 @@ impl BuffOption {
         Some(match self {
             BuffOption::ACCELERATLE => "Acceleratle",
             BuffOption::OOMPH => "Oomph",
-            BuffOption::PSYCHE => "Psyche Up",
             BuffOption::BOUNCE => "Bounce",
+            BuffOption::PSYCHE => "Psyche Up",
             BuffOption::BREATHING => "Deep Breathing",
             BuffOption::ARSENE => "Arsene",
             BuffOption::LIMIT => "Limit Break",

--- a/src/common/menu.rs
+++ b/src/common/menu.rs
@@ -503,6 +503,13 @@ pub unsafe fn write_menu() {
         MedDelay,
         "Pummel Delay: How many frames after a grab to wait before starting to pummel"
     );
+    add_bitflag_submenu!(
+        overall_menu,
+        "Buff Options",
+        buff_state,
+        BuffOption,
+        "Buff Options: Buff(s) to be applied to respective character when loading save states"
+    );
 
     // Slider menus
     overall_menu.add_sub_menu(

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -42,6 +42,7 @@ pub static BASE_MENU: consts::TrainingModpackMenu = consts::TrainingModpackMenu 
     throw_state: ThrowOption::NONE,
     throw_delay: MedDelay::empty(),
     pummel_delay: MedDelay::empty(),
+    buff_state: BuffOption::empty(),
 };
 
 pub static mut DEFAULT_MENU: TrainingModpackMenu = BASE_MENU;

--- a/src/templates/buff_state.svg
+++ b/src/templates/buff_state.svg
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="80.0px"
+   height="80.0px"
+   viewBox="0 0 80.0 80.0"
+   version="1.1"
+   id="SVGRoot"
+   sodipodi:docname="buff_state.svg"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs5503" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#000000"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="8"
+     inkscape:cx="52.625"
+     inkscape:cy="33.6875"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     inkscape:document-rotation="0"
+     showgrid="true"
+     inkscape:window-width="1431"
+     inkscape:window-height="1041"
+     inkscape:window-x="256"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     inkscape:pagecheckerboard="1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid6073"
+       spacingx="0.1"
+       spacingy="0.1" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5506">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <g
+       id="g243"
+       style="fill:#ffffea;fill-opacity:1"
+       transform="matrix(0.54490954,0,0,-0.44245854,-24.388508,217.32339)">
+      <g
+         id="g245"
+         style="fill:#ffffea;fill-opacity:1">
+        <g
+           id="g251"
+           style="fill:#ffffea;fill-opacity:1">
+          <g
+             id="g253"
+             style="fill:#ffffea;fill-opacity:1">
+            <path
+               d="m 58.348,376.03 c 3.332,-50.936 45.698,-55.695 45.698,-55.695 v 0 c -36.178,20.944 -24.437,58.551 -1.666,79.495 v 0 c 13.625,12.533 9.71,21.5 9.313,22.314 v 0 c 7.57,-14.95 1.868,-19.957 -2.411,-37.546 v 0 c -4.284,-17.614 6.188,-36.178 17.613,-33.44 v 0 c 11.424,2.737 5.95,17.969 5.95,17.969 v 0 c 26.419,-26.896 0.952,-44.746 0.952,-44.746 v 0 c 0,0 39.034,10.948 42.604,47.365 v 0 c 3.571,36.415 -25.705,51.411 -25.705,51.411 v 0 c 9.758,-8.093 9.283,-23.327 -1.904,-24.279 v 0 c -11.187,-0.951 -18.089,3.333 -10.71,35.464 v 0 c 7.378,32.132 -34.036,50.457 -34.036,50.457 v 0 C 124.039,438.387 55.015,426.963 58.348,376.03 m 53.314,46.174 c 0,0 0,0 0,0 v 0 c 0,0 0,0 0,0"
+               style="fill:#ffffea;stroke:none;fill-opacity:1"
+               id="path267" />
+          </g>
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/src/training/buff.rs
+++ b/src/training/buff.rs
@@ -75,14 +75,9 @@ fn get_spell_vec() -> Vec<BuffOption> {
 pub unsafe fn handle_buffs(module_accessor: &mut app::BattleObjectModuleAccessor, fighter_kind: i32, status: i32, percent: f32) -> bool {
     SoundModule::stop_all_sound(module_accessor); // silences buff sfx other than KO Punch
     ControlModule::stop_rumble(module_accessor, false);
-    MotionAnimcmdModule::set_sleep(module_accessor, false); // does this prevent all the anims?
+    MotionAnimcmdModule::set_sleep(module_accessor, false);
     //KineticModule::clear_speed_all(module_accessor);
     //CameraModule::stop_quake(module_accessor, 60); // doesn't work
-    //app::sv_animcmd::QUAKE_STOP(60); crashes game very cool
-
-    // This cannot be a match statement because of the pointer derefrencing, 
-    // though you may be able to write something smarter than this like iter over a tuple of your pointer values and use find() or position()
-    // unsure if the above idea has any merit though
 
     let menu_vec = MENU.buff_state.to_vec();
 
@@ -159,21 +154,16 @@ unsafe fn buff_joker(module_accessor: &mut app::BattleObjectModuleAccessor) -> b
         let entry_id = app::FighterEntryID(FighterId::CPU as i32); // strangely, this doesn't actually matter and works for both fighters
         app::FighterSpecializer_Jack::add_rebel_gauge(module_accessor, entry_id, 120.0);
     }
-
     if frame_counter::should_delay(2 as u32, BUFF_DELAY_COUNTER) { // need to wait 2 frames to make sure we stop the voice call, since it's a bit delayed
         return false;
     }
-        
     return true; 
 }
 
 unsafe fn buff_mac(module_accessor: &mut app::BattleObjectModuleAccessor) -> bool {
     WorkModule::set_float(module_accessor, 100.0, *FIGHTER_LITTLEMAC_INSTANCE_WORK_ID_FLOAT_KO_GAGE); // Sets meter to full
-    SoundModule::stop_se(module_accessor,smash::phx::Hash40::new("se_littlemac_kogeuge_burst"), 0);
-
     // Trying to stop KO Punch from playing seems to make it play multiple times in rapid succession. Look at 0x7100c44b60 for the func that handles this
-    // Need to figure out how to update the KO meter. Maybe can just put him in hitstop though, unsure
-    //WorkModule::on_flag(module_accessor, *FIGHTER_LITTLEMAC_INSTANCE_WORK_ID_FLAG_REQUEST_KO_GAUGE_MAX_EFFECT); // doesn't work?
+    // Need to figure out how to update the KO meter if this is fixed
     return true;
 }
 
@@ -200,7 +190,6 @@ unsafe fn buff_wiifit(module_accessor: &mut app::BattleObjectModuleAccessor, sta
         }
         return true;
     }
-    
     let prev_status_kind = StatusModule::prev_status_kind(module_accessor, 0);
     if prev_status_kind == FIGHTER_WIIFIT_STATUS_KIND_SPECIAL_LW_SUCCESS {
         start_buff(module_accessor);

--- a/src/training/buff.rs
+++ b/src/training/buff.rs
@@ -67,5 +67,48 @@ pub unsafe fn get_command_flag_throw_direction(module_accessor: &mut app::Battle
 }
 */
 
+pub unsafe fn handle_buffs(module_accessor: &mut app::BattleObjectModuleAccessor, fighter_kind: i32, status: i32) -> bool {
+    if fighter_kind == *FIGHTER_KIND_BRAVE {
+        return buff_hero(module_accessor,status);
+    }
+    return true;
+}
 
+unsafe fn buff_hero(module_accessor: &mut app::BattleObjectModuleAccessor, status: i32) -> bool {
+    let prev_status_kind = StatusModule::prev_status_kind(module_accessor, 0);
+    println!("Status: {}, Prev: {}", status, prev_status_kind);
+    if prev_status_kind == FIGHTER_BRAVE_STATUS_KIND_SPECIAL_LW_START { //&& buffs_remaining = 0 // If finished applying buffs, need to have some kind of struct responsible
+        return true;
+    }
+    if status != FIGHTER_BRAVE_STATUS_KIND_SPECIAL_LW_START {
+        WorkModule::set_int(module_accessor, 10, *FIGHTER_BRAVE_INSTANCE_WORK_ID_INT_SPECIAL_LW_DECIDE_COMMAND);
+        StatusModule::change_status_force( // _request_from_script?
+            module_accessor,
+            *FIGHTER_BRAVE_STATUS_KIND_SPECIAL_LW_START,
+            false,
+        );
+    } else {
+        MotionModule::set_rate(module_accessor, 40.0);
+    }
+    return false;
+}
 
+unsafe fn _buff_cloud(module_accessor: &mut app::BattleObjectModuleAccessor) {
+
+}
+
+unsafe fn _buff_joker(module_accessor: &mut app::BattleObjectModuleAccessor) {
+
+}
+
+unsafe fn _buff_mac(module_accessor: &mut app::BattleObjectModuleAccessor) {
+
+}
+
+unsafe fn _buff_sepiroth(module_accessor: &mut app::BattleObjectModuleAccessor) {
+
+}
+
+unsafe fn _buff_wiifit(module_accessor: &mut app::BattleObjectModuleAccessor) {
+
+}

--- a/src/training/buff.rs
+++ b/src/training/buff.rs
@@ -1,4 +1,6 @@
 use crate::common::consts::*;
+use smash::hash40;
+//use crate::common::consts::FighterId;
 use crate::common::*;
 use crate::training::frame_counter;
 use crate::training::mash;
@@ -68,21 +70,27 @@ pub unsafe fn get_command_flag_throw_direction(module_accessor: &mut app::Battle
 */
 
 pub unsafe fn handle_buffs(module_accessor: &mut app::BattleObjectModuleAccessor, fighter_kind: i32, status: i32) -> bool {
+    SoundModule::stop_all_sound(module_accessor); // should silence voice lines etc. need to test on every buff
     if fighter_kind == *FIGHTER_KIND_BRAVE {
         return buff_hero(module_accessor,status);
+    } else if fighter_kind == *FIGHTER_KIND_JACK {
+        return buff_joker(module_accessor,status);
+    } else if fighter_kind == *FIGHTER_KIND_WIIFIT {
+        return buff_wiifit(module_accessor,status);
+    } else if fighter_kind == *FIGHTER_KIND_CLOUD {
+        return buff_cloud(module_accessor, status);
     }
     return true;
 }
 
 unsafe fn buff_hero(module_accessor: &mut app::BattleObjectModuleAccessor, status: i32) -> bool {
     let prev_status_kind = StatusModule::prev_status_kind(module_accessor, 0);
-    println!("Status: {}, Prev: {}", status, prev_status_kind);
     if prev_status_kind == FIGHTER_BRAVE_STATUS_KIND_SPECIAL_LW_START { //&& buffs_remaining = 0 // If finished applying buffs, need to have some kind of struct responsible
         return true;
     }
     if status != FIGHTER_BRAVE_STATUS_KIND_SPECIAL_LW_START {
         WorkModule::set_int(module_accessor, 10, *FIGHTER_BRAVE_INSTANCE_WORK_ID_INT_SPECIAL_LW_DECIDE_COMMAND);
-        StatusModule::change_status_force( // _request_from_script?
+        StatusModule::change_status_force( // _request_from_script? - no, because you need to override shield buffer
             module_accessor,
             *FIGHTER_BRAVE_STATUS_KIND_SPECIAL_LW_START,
             false,
@@ -93,22 +101,93 @@ unsafe fn buff_hero(module_accessor: &mut app::BattleObjectModuleAccessor, statu
     return false;
 }
 
-unsafe fn _buff_cloud(module_accessor: &mut app::BattleObjectModuleAccessor) {
+unsafe fn buff_cloud(module_accessor: &mut app::BattleObjectModuleAccessor, status: i32) -> bool {
+    //WorkModule::set_flag(module_accessor, true, *FIGHTER_CLOUD_INSTANCE_WORK_ID_FLAG_LIMIT_GAUGE_CHARGE);
+    //WorkModule::set_flag(module_accessor, true, *FIGHTER_CLOUD_INSTANCE_WORK_ID_FLAG_LIMIT_BREAK);
+    //return true; // change to false when implemented
+    //FIGHTER_CLOUD_INSTANCE_WORK_ID_FLAG_LIMIT_GAUGE_CHARGE
+    //FIGHTER_CLOUD_INSTANCE_WORK_ID_FLAG_LIMIT_BREAK
+    //FIGHTER_CLOUD_INSTANCE_WORK_ID_FLAG_LIMIT_BREAK_SET_CUSTOM
+    //FIGHTER_CLOUD_INSTANCE_WORK_ID_FLAG_LIMIT_BREAK_SPECIAL
+    //FIGHTER_CLOUD_INSTANCE_WORK_ID_FLOAT_LIMIT_GAUGE
+    //FIGHTER_CLOUD_INSTANCE_WORK_ID_FLOAT_CATCH_CUT_DAMAGE
+    //FIGHTER_CLOUD_INSTANCE_WORK_ID_FLOAT_LIMIT_GAUGE_NOTICE
+
+    //Prevent beginning from being shield cancellable? The limit end animation is a problem too. Maybe params aren't the best way to
+    //  go about initially setting the status here (but should probably still be used to allow for instant limit charge? Not sure)
+
+    println!("limit_gauge_add = {}", hash40("limit_gauge_add"));
+    let prev_status_kind = StatusModule::prev_status_kind(module_accessor, 0);
+    if prev_status_kind == FIGHTER_CLOUD_STATUS_KIND_SPECIAL_LW_CHARGE {
+        return true;
+    }
+    if status != FIGHTER_CLOUD_STATUS_KIND_SPECIAL_LW_CHARGE {
+        StatusModule::change_status_force(
+            module_accessor,
+            *FIGHTER_CLOUD_STATUS_KIND_SPECIAL_LW_CHARGE,
+            false,
+        );
+    } else {
+        MotionModule::set_rate(module_accessor, 300.0); // frame count for limit? Too high?
+    }
+    return false;
 
 }
 
-unsafe fn _buff_joker(module_accessor: &mut app::BattleObjectModuleAccessor) {
+unsafe fn buff_joker(module_accessor: &mut app::BattleObjectModuleAccessor, status: i32) -> bool {
+    // call function to add/set rebel gauge
+    // if none exists, edit param over time to give you exact gauge needed for arsene (or more) when loading save state
+    // if can't figure that out, super speed up rebel's guard attack and make it give insane meter or something
+    // Also, maybe try to make the arsene voice call not happen?
+    let entry_id = app::FighterEntryID(FighterId::Player as i32); // may need to be 0? // May want to apply to CPU? For 2 framing?
+    app::FighterSpecializer_Jack::add_rebel_gauge(module_accessor, entry_id, 120.0); // Why do I need to use app:: when I don't need to for other Modules?
+    // prevent cutscene, may want to do in enable_transition_term or something
+    
+    //MotionModule::set_frame(48.0); // try these
+    //CancelModule::enable_cancel(boma);
+    
+    /*if transition_term == *FIGHTER_JACK_STATUS_KIND_SUMMON {
+        return false;
+    }*/ // in mod.rs /training didn't work
 
+    //WorkModule::unable_transition_term(module_accessor, *FIGHTER_JACK_STATUS_KIND_SUMMON);
+    //WorkModule::enable_transition_term_forbid(module_accessor, *FIGHTER_JACK_STATUS_KIND_SUMMON);
+   
+    /*let prev_status_kind = StatusModule::prev_status_kind(module_accessor, 0);
+    if status == FIGHTER_JACK_STATUS_KIND_SUMMON { //&& buffs_remaining = 0 // If finished applying buffs, need to have some kind of struct responsible
+        StatusModule::change_status_force( // _request_from_script?
+            module_accessor,
+            prev_status_kind,
+            false,
+        );
+    }*/
+    
+    // add some check for if Arsene is actually out here?
+    return true; // change to false when implemented
 }
 
-unsafe fn _buff_mac(module_accessor: &mut app::BattleObjectModuleAccessor) {
-
+unsafe fn _buff_mac(module_accessor: &mut app::BattleObjectModuleAccessor) -> bool {
+    return true; // change to false when implemented
+    //FIGHTER_LITTLEMAC_INSTANCE_WORK_ID_FLOAT_KO_GAGE
 }
 
-unsafe fn _buff_sepiroth(module_accessor: &mut app::BattleObjectModuleAccessor) {
-
+unsafe fn _buff_sepiroth(module_accessor: &mut app::BattleObjectModuleAccessor) -> bool {
+    return true; // change to false when implemented
 }
 
-unsafe fn _buff_wiifit(module_accessor: &mut app::BattleObjectModuleAccessor) {
-
+unsafe fn buff_wiifit(module_accessor: &mut app::BattleObjectModuleAccessor, status: i32) -> bool {
+    let prev_status_kind = StatusModule::prev_status_kind(module_accessor, 0);
+    if prev_status_kind == FIGHTER_WIIFIT_STATUS_KIND_SPECIAL_LW_SUCCESS {
+        return true;
+    }
+    if status != FIGHTER_WIIFIT_STATUS_KIND_SPECIAL_LW_SUCCESS {
+        StatusModule::change_status_force(
+            module_accessor,
+            *FIGHTER_WIIFIT_STATUS_KIND_SPECIAL_LW_SUCCESS,
+            false,
+        );
+    } else {
+        MotionModule::set_rate(module_accessor, 40.0); // frame count for deep breathing???
+    }
+    return false;
 }

--- a/src/training/buff.rs
+++ b/src/training/buff.rs
@@ -2,21 +2,31 @@ use crate::common::consts::*;
 use crate::common::*;
 use smash::app::{self, lua_bind::*};
 use smash::lib::lua_const::*;
-use crate::training::cloud_func_hook;
+use crate::training::handle_add_limit;
+use crate::training::frame_counter;
+
+static mut BUFF_DELAY_COUNTER: usize = 0;
 
 static mut BUFF_REMAINING: i32 = 0;
-static mut NUM_OPERATIONS: i32 = 0;
 static mut IS_BUFFING: bool = false;
 
-pub fn restart_buff() {
+pub fn init() {
     unsafe {
-        IS_BUFFING = false;
+        BUFF_DELAY_COUNTER = frame_counter::register_counter();
     }
 }
 
-fn get_spell_vec() -> Vec<BuffOption> { // prob unneeded
+pub unsafe fn restart_buff() {
+    IS_BUFFING = false;
+}
+
+pub unsafe fn is_buffing() -> bool {
+    return IS_BUFFING;
+}
+
+
+fn get_spell_vec() -> Vec<BuffOption> {
     unsafe {
-        //let spell_buff = vec![BuffOption::OOMPH,BuffOption::PSYCHE,BuffOption::BOUNCE,BuffOption::ACCELERATLE];
         let menu_buff = MENU.buff_state.to_vec();
         let menu_iter = menu_buff.iter();
         let mut spell_buff: Vec<BuffOption> = Vec::new();
@@ -30,16 +40,13 @@ fn get_spell_vec() -> Vec<BuffOption> { // prob unneeded
 }
 
 pub unsafe fn handle_buffs(module_accessor: &mut app::BattleObjectModuleAccessor, fighter_kind: i32, status: i32, percent: f32) -> bool {
-    SoundModule::stop_all_sound(module_accessor); // should silence voice lines etc. need to test on every buff
-    //MotionAnimcmdModule::set_sleep(module_accessor, false); // does this prevent all the anims?
-    SoundModule::pause_se_all(module_accessor, false);
+    SoundModule::stop_all_sound(module_accessor); // silences buff sfx other than KO Punch
     ControlModule::stop_rumble(module_accessor, false);
+    MotionAnimcmdModule::set_sleep(module_accessor, false); // does this prevent all the anims?
     //KineticModule::clear_speed_all(module_accessor);
-    //ShakeModule::stop(module_accessor); // doesn't work?
     //CameraModule::stop_quake(module_accessor, 60); // doesn't work
     //app::sv_animcmd::QUAKE_STOP(60); crashes game very cool
 
-    //fix psyche up camera shake?
     // This cannot be a match statement because of the pointer derefrencing, 
     // though you may be able to write something smarter than this like iter over a tuple of your pointer values and use find() or position()
     // unsure if the above idea has any merit though
@@ -49,13 +56,13 @@ pub unsafe fn handle_buffs(module_accessor: &mut app::BattleObjectModuleAccessor
     if fighter_kind == *FIGHTER_KIND_BRAVE {
         return buff_hero(module_accessor,status);
     } else if fighter_kind == *FIGHTER_KIND_JACK && menu_vec.contains(&BuffOption::ARSENE) {
-        return buff_joker(module_accessor,status);
+        return buff_joker(module_accessor);
     } else if fighter_kind == *FIGHTER_KIND_WIIFIT && menu_vec.contains(&BuffOption::BREATHING) {
         return buff_wiifit(module_accessor,status);
     } else if fighter_kind == *FIGHTER_KIND_CLOUD && menu_vec.contains(&BuffOption::LIMIT) {
-        return buff_cloud(module_accessor, status);
+        return buff_cloud(module_accessor);
     } else if fighter_kind == *FIGHTER_KIND_LITTLEMAC && menu_vec.contains(&BuffOption::KO) {
-        return buff_mac(module_accessor, status);
+        return buff_mac(module_accessor);
     } else if fighter_kind == *FIGHTER_KIND_EDGE && menu_vec.contains(&BuffOption::WING) {
         return buff_sepiroth(module_accessor, percent);
     }
@@ -63,16 +70,11 @@ pub unsafe fn handle_buffs(module_accessor: &mut app::BattleObjectModuleAccessor
     return true;
 }
 
-// Probably should have some vector of the statuses selected on the Menu, and for each status you
-// have the framecounter delay be its index (0 for first, 1 frame/index for second, etc.), this probably goes backwards? Unsure
-// probably better to just always call the first if its not empty, but won't cause idk how
-
 unsafe fn buff_hero(module_accessor: &mut app::BattleObjectModuleAccessor, status: i32) -> bool {
     let buff_vec = get_spell_vec();
     if !IS_BUFFING { // should I do 0 or 1? Initial set up for spells
         IS_BUFFING = true; // This should be fine, as starting it multiple times per frame shouldn't be an issue. Start counting
-        NUM_OPERATIONS = 0;
-        BUFF_REMAINING = buff_vec.len() as i32; // since its the first frame, we need to set up how many buffs there are
+        BUFF_REMAINING = buff_vec.len() as i32; // since its the first step of buffing, we need to set up how many buffs there are
     } // else { // commands to use if we're buffing, does this else need to be here?
     if BUFF_REMAINING <= 0 { // If there are no buffs selected/left, get out of here
         return true; // this may be needed since we're casting a potential -1 to usize?
@@ -82,7 +84,6 @@ unsafe fn buff_hero(module_accessor: &mut app::BattleObjectModuleAccessor, statu
 }
 
 unsafe fn buff_hero_single(module_accessor: &mut app::BattleObjectModuleAccessor, status: i32, buff_vec: Vec<BuffOption>) {
-    NUM_OPERATIONS += 1;
     let prev_status_kind = StatusModule::prev_status_kind(module_accessor, 0);
     if prev_status_kind == FIGHTER_BRAVE_STATUS_KIND_SPECIAL_LW_START { //&& buffs_remaining = 0 // If finished applying buffs, need to have some kind of struct responsible
         BUFF_REMAINING -= 1;
@@ -95,7 +96,7 @@ unsafe fn buff_hero_single(module_accessor: &mut app::BattleObjectModuleAccessor
     }
     let real_spell_value = spell_option.unwrap().into_int().unwrap();
     if status != FIGHTER_BRAVE_STATUS_KIND_SPECIAL_LW_START && BUFF_REMAINING != 0 { // probably needed
-        WorkModule::set_int(module_accessor, real_spell_value, *FIGHTER_BRAVE_INSTANCE_WORK_ID_INT_SPECIAL_LW_DECIDE_COMMAND); // not being set at right time
+        WorkModule::set_int(module_accessor, real_spell_value, *FIGHTER_BRAVE_INSTANCE_WORK_ID_INT_SPECIAL_LW_DECIDE_COMMAND);
         StatusModule::change_status_force( // does this crash if forcing while already in the status?
             module_accessor,
             *FIGHTER_BRAVE_STATUS_KIND_SPECIAL_LW_START,
@@ -106,84 +107,49 @@ unsafe fn buff_hero_single(module_accessor: &mut app::BattleObjectModuleAccessor
         MotionModule::set_rate(module_accessor, 50.0); //needs to be at least 46 for psyche up?
     }
 }
-/*
-unsafe fn _buff_cloud(module_accessor: &mut app::BattleObjectModuleAccessor, status: i32) -> bool {
-    println!("Next Status: {}", StatusModule::status_kind_next(module_accessor));
-    let prev_status_kind = StatusModule::prev_status_kind(module_accessor, 0);
-    if prev_status_kind == FIGHTER_CLOUD_STATUS_KIND_SPECIAL_LW_END {
-        //KineticModule::clear_speed_all(module_accessor);
-        return true;
-    }
-    if !IS_BUFFING {
+
+unsafe fn buff_cloud(module_accessor: &mut app::BattleObjectModuleAccessor) -> bool {
+    if !IS_BUFFING { // only need to set limit gauge once
         IS_BUFFING = true;
-        WorkModule::set_float(module_accessor, 100.0, *FIGHTER_CLOUD_INSTANCE_WORK_ID_FLOAT_LIMIT_GAUGE);
-        StatusModule::change_status_request_from_script( // not doing from_script crashes the game here
-            module_accessor,
-            *FIGHTER_CLOUD_STATUS_KIND_SPECIAL_LW_CHARGE,
-            true, // originally false, probably should be true though so inputs aren't interfered with as we go through multiple buffs
-        );
-    } 
-    MotionModule::set_rate(module_accessor, 50.0);
-    return false;
-}
-*/
-unsafe fn buff_cloud(module_accessor: &mut app::BattleObjectModuleAccessor, status: i32) -> bool {
-    //WorkModule::set_float(module_accessor, 99.0, *FIGHTER_CLOUD_INSTANCE_WORK_ID_FLOAT_LIMIT_GAUGE);
-    cloud_func_hook(100.0,module_accessor,0);
+        handle_add_limit(100.0,module_accessor,0);
+    }
+    if frame_counter::should_delay(2 as u32, BUFF_DELAY_COUNTER) { // need to wait 2 frames to make sure we stop the limit SFX, since it's a bit delayed
+        return false;
+    } // see if stop se stuff works for this, or if I should just stop the limit line 
     return true;
 }
 
-unsafe fn buff_joker(module_accessor: &mut app::BattleObjectModuleAccessor, status: i32) -> bool {
-    // call function to add/set rebel gauge
-    // if none exists, edit param over time to give you exact gauge needed for arsene (or more) when loading save state
-    // if can't figure that out, super speed up rebel's guard attack and make it give insane meter or something
-    // Also, maybe try to make the arsene voice call not happen?
-    let entry_id = app::FighterEntryID(FighterId::Player as i32); // may need to be 0? // May want to apply to CPU? For 2 framing?
-    app::FighterSpecializer_Jack::add_rebel_gauge(module_accessor, entry_id, 120.0); // Why do I need to use app:: when I don't need to for other Modules?
-    // prevent cutscene, may want to do in enable_transition_term or something
-    
-    //MotionModule::set_frame(48.0); // try these
-    //CancelModule::enable_cancel(boma);
-    
-    /*if transition_term == *FIGHTER_JACK_STATUS_KIND_SUMMON {
-        return false;
-    }*/ // in mod.rs /training didn't work
+unsafe fn buff_joker(module_accessor: &mut app::BattleObjectModuleAccessor) -> bool {
+    if !IS_BUFFING { // only need to set rebel gauge once
+        IS_BUFFING = true;
+        let entry_id = app::FighterEntryID(FighterId::Player as i32); // may need to be 0? // May want to apply to CPU? For 2 framing?
+        app::FighterSpecializer_Jack::add_rebel_gauge(module_accessor, entry_id, 120.0); // Why do I need to use app:: when I don't need to for other Modules?
+    }
 
-    //WorkModule::unable_transition_term(module_accessor, *FIGHTER_JACK_STATUS_KIND_SUMMON);
-    //WorkModule::enable_transition_term_forbid(module_accessor, *FIGHTER_JACK_STATUS_KIND_SUMMON);
-   
-    /*let prev_status_kind = StatusModule::prev_status_kind(module_accessor, 0);
-    if status == FIGHTER_JACK_STATUS_KIND_SUMMON { //&& buffs_remaining = 0 // If finished applying buffs, need to have some kind of struct responsible
-        StatusModule::change_status_force( // _request_from_script?
-            module_accessor,
-            prev_status_kind,
-            false,
-        );
-    }*/
-    
-    // add some check for if Arsene is actually out here?
-    return true; // change to false when implemented
+    if frame_counter::should_delay(5 as u32, BUFF_DELAY_COUNTER) { // need to wait 5 frames to make sure we stop the voice call, since it's a bit delayed
+        return false;
+    }
+        
+    return true; 
 }
 
-unsafe fn buff_mac(module_accessor: &mut app::BattleObjectModuleAccessor, status: i32) -> bool {
-    WorkModule::set_float(module_accessor, 100.0, *FIGHTER_LITTLEMAC_INSTANCE_WORK_ID_FLOAT_KO_GAGE); // Sets meter to proper amount
+unsafe fn buff_mac(module_accessor: &mut app::BattleObjectModuleAccessor) -> bool {
+    if !IS_BUFFING { // only need to set rebel gauge once
+        IS_BUFFING = true;
+        WorkModule::set_float(module_accessor, 100.0, *FIGHTER_LITTLEMAC_INSTANCE_WORK_ID_FLOAT_KO_GAGE); // Sets meter to full
+    }
+    //WorkModule::on_flag(module_accessor, *FIGHTER_LITTLEMAC_INSTANCE_WORK_ID_FLAG_REQUEST_KO_GAUGE_MAX_EFFECT); // doesn't work?
+    SoundModule::stop_se(module_accessor,smash::phx::Hash40::new("se_littlemac_kogeuge_burst"), 0);
+    /*if frame_counter::should_delay(10 as u32, BUFF_DELAY_COUNTER) { // need to wait 3 frames to stop the KO Punch SFX
+        return false;
+    }*/
+    // Trying to stop KO Punch from playing seems to make it play multiple times in rapid succession. Look at 0x7100c44b60 for the func that handles this
     // Need to figure out how to update the KO meter. Probably a fighter specializer function? Maybe can just put him in hitstop though, unsure
-    return true; // change to false when implemented
+    return true;
 }
 
 unsafe fn buff_sepiroth(module_accessor: &mut app::BattleObjectModuleAccessor, percent: f32) -> bool {
-    //WorkModule::on_flag(module_accessor, *FIGHTER_EDGE_INSTANCE_WORK_ID_FLAG_ONE_WINGED_ACTIVATED);
-    //~~~WorkModule::on_flag(module_accessor, *FIGHTER_EDGE_INSTANCE_WORK_ID_FLAG_ONE_WINGED_END_ACTIVATE);
-    //WorkModule::set_float(module_accessor, 0.0, *FIGHTER_EDGE_INSTANCE_WORK_ID_FLOAT_ONE_WINGED_THRESHOLD_ACTIVATE_POINT);
-    //WorkModule::set_float(module_accessor, 100.0, *FIGHTER_EDGE_INSTANCE_WORK_ID_FLOAT_ONE_WINGED_ACTIVATE_POINT);
-    //WorkModule::set_float(module_accessor, 0.0, *FIGHTER_EDGE_INSTANCE_WORK_ID_FLOAT_ONE_WINGED_DAMAGE_DIFF_MIN);
-    //WorkModule::set_int(module_accessor, 1, *FIGHTER_EDGE_INSTANCE_WORK_ID_INT_ONE_WINGED_WING_STATE);
-    //WorkModule::set_int(module_accessor, 2, *FIGHTER_EDGE_INSTANCE_WORK_ID_INT_ONE_WINGED_PROCESS);
-    //DamageModule::add_damage(module_accessor,-100.0 ,0);
-    //if damage > min(999.00,damage + 100) - 100
-    //fix damage
-    if WorkModule::get_int(module_accessor, *FIGHTER_EDGE_INSTANCE_WORK_ID_INT_ONE_WINGED_WING_STATE) == 1 { // use flag instead? or find a faster way to do this
-                                                                                                                        // since this comes out like frame 3
+    if WorkModule::get_int(module_accessor, *FIGHTER_EDGE_INSTANCE_WORK_ID_INT_ONE_WINGED_WING_STATE) == 1 { // once we're in wing, heal to correct damage
         DamageModule::heal(
             module_accessor,
             -1.0 * DamageModule::damage(module_accessor, 0),
@@ -191,19 +157,10 @@ unsafe fn buff_sepiroth(module_accessor: &mut app::BattleObjectModuleAccessor, p
         );
         DamageModule::add_damage(module_accessor, percent, 0);
         return true;
-    } else {
+    } else { // if we're not in wing, add damage
         DamageModule::add_damage(module_accessor, 1000.0, 0);
     }
-    return false; // change to false when implemented
-    //FIGHTER_EDGE_INSTANCE_WORK_ID_INT_ONE_WINGED_WING_STATE
-    //FIGHTER_EDGE_INSTANCE_WORK_ID_INT_ONE_WINGED_PROCESS
-    //FIGHTER_EDGE_INSTANCE_WORK_ID_FLOAT_ONE_WINGED_THRESHOLD_ACTIVATE_POINT
-    //FIGHTER_EDGE_INSTANCE_WORK_ID_FLOAT_ONE_WINGED_ACTIVATE_POINT
-    //FIGHTER_EDGE_INSTANCE_WORK_ID_FLOAT_ONE_WINGED_DAMAGE_DIFF_MIN
-    //FIGHTER_EDGE_INSTANCE_WORK_ID_FLAG_ONE_WINGED_ACTIVATED
-    //FIGHTER_EDGE_INSTANCE_WORK_ID_FLAG_ONE_WINGED_END_ACTIVATE
-
-
+    return false;
 }
 
 unsafe fn buff_wiifit(module_accessor: &mut app::BattleObjectModuleAccessor, status: i32) -> bool {

--- a/src/training/buff.rs
+++ b/src/training/buff.rs
@@ -58,7 +58,6 @@ pub unsafe fn get_buff_rem(module_accessor: &mut app::BattleObjectModuleAccessor
     return BUFF_REMAINING_PLAYER;
 }
 
-
 fn get_spell_vec() -> Vec<BuffOption> {
     unsafe {
         let menu_buff = MENU.buff_state.to_vec();
@@ -161,7 +160,7 @@ unsafe fn buff_joker(module_accessor: &mut app::BattleObjectModuleAccessor) -> b
         app::FighterSpecializer_Jack::add_rebel_gauge(module_accessor, entry_id, 120.0);
     }
 
-    if frame_counter::should_delay(5 as u32, BUFF_DELAY_COUNTER) { // need to wait 5 frames to make sure we stop the voice call, since it's a bit delayed
+    if frame_counter::should_delay(2 as u32, BUFF_DELAY_COUNTER) { // need to wait 2 frames to make sure we stop the voice call, since it's a bit delayed
         return false;
     }
         
@@ -179,6 +178,7 @@ unsafe fn buff_mac(module_accessor: &mut app::BattleObjectModuleAccessor) -> boo
 }
 
 unsafe fn buff_sepiroth(module_accessor: &mut app::BattleObjectModuleAccessor, percent: f32) -> bool {
+    start_buff(module_accessor);
     if WorkModule::get_int(module_accessor, *FIGHTER_EDGE_INSTANCE_WORK_ID_INT_ONE_WINGED_WING_STATE) == 1 { // once we're in wing, heal to correct damage
         DamageModule::heal(
             module_accessor,
@@ -194,9 +194,17 @@ unsafe fn buff_sepiroth(module_accessor: &mut app::BattleObjectModuleAccessor, p
 }
 
 unsafe fn buff_wiifit(module_accessor: &mut app::BattleObjectModuleAccessor, status: i32) -> bool {
+    if is_buffing(module_accessor) {
+        if frame_counter::should_delay(2 as u32, BUFF_DELAY_COUNTER) { // need to wait 2 frames to make sure we stop the breathing SFX
+            return false;
+        }
+        return true;
+    }
+    
     let prev_status_kind = StatusModule::prev_status_kind(module_accessor, 0);
     if prev_status_kind == FIGHTER_WIIFIT_STATUS_KIND_SPECIAL_LW_SUCCESS {
-        return true;
+        start_buff(module_accessor);
+        return false;
     }
     if status != FIGHTER_WIIFIT_STATUS_KIND_SPECIAL_LW_SUCCESS {
         StatusModule::change_status_force(

--- a/src/training/buff.rs
+++ b/src/training/buff.rs
@@ -149,7 +149,7 @@ unsafe fn buff_cloud(module_accessor: &mut app::BattleObjectModuleAccessor) -> b
         handle_add_limit(100.0,module_accessor,0);
     }
     if frame_counter::should_delay(2 as u32, BUFF_DELAY_COUNTER) { 
-        // need to wait 2 frames to make sure we stop the limit SFX, since it's a bit delayed
+        // Need to wait 2 frames to make sure we stop the limit SFX, since it's a bit delayed
         return false;
     }
     return true;
@@ -171,7 +171,8 @@ unsafe fn buff_joker(module_accessor: &mut app::BattleObjectModuleAccessor) -> b
 
 unsafe fn buff_mac(module_accessor: &mut app::BattleObjectModuleAccessor) -> bool {
     WorkModule::set_float(module_accessor, 100.0, *FIGHTER_LITTLEMAC_INSTANCE_WORK_ID_FLOAT_KO_GAGE);
-    // Trying to stop KO Punch from playing seems to make it play multiple times in rapid succession. Look at 0x7100c44b60 for the func that handles this
+    // Trying to stop KO Punch from playing seems to make it play multiple times in rapid succession
+    // Look at 0x7100c44b60 for the func that handles this
     // Need to figure out how to update the KO meter if this is fixed
     return true;
 }
@@ -179,7 +180,7 @@ unsafe fn buff_mac(module_accessor: &mut app::BattleObjectModuleAccessor) -> boo
 unsafe fn buff_sepiroth(module_accessor: &mut app::BattleObjectModuleAccessor, percent: f32) -> bool {
     start_buff(module_accessor);
     if WorkModule::get_int(module_accessor, *FIGHTER_EDGE_INSTANCE_WORK_ID_INT_ONE_WINGED_WING_STATE) == 1 { 
-        // once we're in wing, heal to correct damage
+        // Once we're in wing, heal to correct damage
         DamageModule::heal(
             module_accessor,
             -1.0 * DamageModule::damage(module_accessor, 0),

--- a/src/training/buff.rs
+++ b/src/training/buff.rs
@@ -1,0 +1,71 @@
+use crate::common::consts::*;
+use crate::common::*;
+use crate::training::frame_counter;
+use crate::training::mash;
+use smash::app::{self, lua_bind::*};
+use smash::lib::lua_const::*;
+
+/*const NOT_SET: u32 = 9001;
+static mut THROW_DELAY: u32 = NOT_SET;
+static mut THROW_DELAY_COUNTER: usize = 0;
+static mut THROW_CASE: ThrowOption = ThrowOption::empty();
+
+pub fn init() {
+    unsafe {
+        THROW_DELAY_COUNTER = frame_counter::register_counter();
+    }
+}*/
+
+/*
+// Rolling Throw Delays and Pummel Delays separately
+
+pub fn reset_throw_delay() {
+    unsafe {
+        if THROW_DELAY != NOT_SET {
+            THROW_DELAY = NOT_SET;
+            frame_counter::full_reset(THROW_DELAY_COUNTER);
+        }
+    }
+}
+
+pub fn reset_throw_case() {
+    unsafe {
+        if THROW_CASE != ThrowOption::empty() {
+            // Don't roll another throw option if one is already selected
+            THROW_CASE = ThrowOption::empty();
+        }
+    }
+}
+
+fn roll_throw_delay() {
+    unsafe {
+        if THROW_DELAY != NOT_SET {
+            // Don't roll another throw delay if one is already selected
+            return;
+        }
+
+        THROW_DELAY = MENU.throw_delay.get_random().into_meddelay();
+    }
+}
+
+
+fn roll_throw_case() {
+    unsafe {
+        // Don't re-roll if there is already a throw option selected
+        if THROW_CASE != ThrowOption::empty() {
+            return;
+        }
+
+        THROW_CASE = MENU.throw_state.get_random();
+    }
+}
+*/
+
+/*
+pub unsafe fn get_command_flag_throw_direction(module_accessor: &mut app::BattleObjectModuleAccessor) -> i32 {
+
+}
+*/
+
+
+

--- a/src/training/buff.rs
+++ b/src/training/buff.rs
@@ -76,8 +76,6 @@ pub unsafe fn handle_buffs(module_accessor: &mut app::BattleObjectModuleAccessor
     SoundModule::stop_all_sound(module_accessor); // silences buff sfx other than KO Punch
     ControlModule::stop_rumble(module_accessor, false);
     MotionAnimcmdModule::set_sleep(module_accessor, false);
-    //KineticModule::clear_speed_all(module_accessor);
-    //CameraModule::stop_quake(module_accessor, 60); // doesn't work
 
     let menu_vec = MENU.buff_state.to_vec();
 

--- a/src/training/mod.rs
+++ b/src/training/mod.rs
@@ -105,6 +105,30 @@ fn once_per_frame_per_fighter(
             crate::common::menu::spawn_menu();
         }
 
+        let fighter_kind = app::utility::get_kind(module_accessor);
+        let fighter_is_brave = fighter_kind == *FIGHTER_KIND_BRAVE;
+        if fighter_is_brave {
+            let status_kind = StatusModule::status_kind(module_accessor) as i32;
+            let prev_status_kind = StatusModule::prev_status_kind(module_accessor, 0);
+            //println!("Brave Status: {}, SPD-UP = {}, START = {}", status_kind, *FIGHTER_BRAVE_SPECIAL_LW_COMMAND11_SPEED_UP, *FIGHTER_BRAVE_STATUS_KIND_SPECIAL_LW_START);
+            
+            //println!("Select = ");
+
+            println!("Brave Status: {}, Work_Int_Decide = {}, Fighter Log Attack Kind (How many frames have fallen at max fall speed?) = {}", status_kind, WorkModule::get_int(module_accessor,*FIGHTER_BRAVE_INSTANCE_WORK_ID_INT_SPECIAL_LW_DECIDE_COMMAND), WorkModule::get_int(module_accessor,*FIGHTER_LOG_DATA_INT_ATTACK_NUM_KIND));
+            
+            /*
+            if status_kind == 493 { // menu
+                StatusModule::change_status_request_from_script(module_accessor, 497, true);
+                WorkModule::set_int(module_accessor, 10, *FIGHTER_BRAVE_INSTANCE_WORK_ID_INT_SPECIAL_LW_DECIDE_COMMAND); // probably should have this after status? unsure
+            }
+            if status_kind == 497 { // instant spell, makes nothing happen aside from mp loss
+                StatusModule::change_status_request_from_script(module_accessor, 0, true);
+                WorkModule::unable_transition_term(module_accessor, 44);
+            }
+            */
+        }
+        
+
         input_record::get_command_flag_cat(module_accessor);
         combo::get_command_flag_cat(module_accessor);
         hitbox_visualizer::get_command_flag_cat(module_accessor);

--- a/src/training/mod.rs
+++ b/src/training/mod.rs
@@ -114,7 +114,7 @@ fn once_per_frame_per_fighter(
         hitbox_visualizer::get_command_flag_cat(module_accessor);
         save_states::save_states(module_accessor);
         tech::get_command_flag_cat(module_accessor);
-
+        /*
         if !is_operation_cpu(module_accessor) {
             //println!("Cloud Limit Gauge: {}", WorkModule::get_float(module_accessor, *FIGHTER_CLOUD_INSTANCE_WORK_ID_FLOAT_LIMIT_GAUGE));
             println!("Edge Thresh: {}, Activate: {}, Damage Diff Min: {}, FlagAct'd: {}, FlagEnd: {}, State: {}, Process: {}", 
@@ -128,6 +128,7 @@ fn once_per_frame_per_fighter(
             );
 
         }
+        */
 
     }
 
@@ -381,4 +382,5 @@ pub fn training_mods() {
     ledge::init();
     throw::init();
     menu::init();
+    buff::init();
 }

--- a/src/training/mod.rs
+++ b/src/training/mod.rs
@@ -31,6 +31,12 @@ mod reset;
 mod save_states;
 mod shield_tilt;
 
+static CLOUD_OFFSET: usize = 0x008dc140; // this function is used to add limit to Cloud's limit gauge. Hooking it here so we can call it in buff.rs
+#[skyline::hook(offset = CLOUD_OFFSET)]
+pub unsafe fn cloud_func_hook(add_limit: f32, module_accessor: &mut app::BattleObjectModuleAccessor, is_specialLw: u64) {
+    original!()(add_limit,module_accessor,is_specialLw)
+}
+
 #[skyline::hook(replace = WorkModule::get_param_float)]
 pub unsafe fn handle_get_param_float(
     module_accessor: &mut app::BattleObjectModuleAccessor,
@@ -373,6 +379,7 @@ pub fn training_mods() {
         crate::training::sdi::check_hit_stop_delay_command,
         // Buffs
         //get_param_float_hook,
+        cloud_func_hook,
     );
 
     combo::init();
@@ -382,5 +389,4 @@ pub fn training_mods() {
     ledge::init();
     throw::init();
     menu::init();
-    buff::init();
 }

--- a/src/training/mod.rs
+++ b/src/training/mod.rs
@@ -104,7 +104,20 @@ fn once_per_frame_per_fighter(
         if crate::common::menu::menu_condition(module_accessor) {
             crate::common::menu::spawn_menu();
         }
-
+        /*
+        let fighter_kind = app::utility::get_kind(module_accessor);
+        let fighter_is_brave = fighter_kind == *FIGHTER_KIND_BRAVE;
+        if fighter_is_brave {
+            if status_kind == 497 { // instant spell, makes nothing happen aside from mp loss
+                //StatusModule::change_status_request_from_script(module_accessor, 0, true);
+                //WorkModule::unable_transition_term(module_accessor, 44);
+                //let current_frame = MotionModule::frame(module_accessor);
+                //println!("Current Spell Frame: {}",current_frame);
+                MotionModule::set_rate(module_accessor, 40.0);
+            }
+        }
+        */
+        /*
         let fighter_kind = app::utility::get_kind(module_accessor);
         let fighter_is_brave = fighter_kind == *FIGHTER_KIND_BRAVE;
         if fighter_is_brave {
@@ -114,19 +127,22 @@ fn once_per_frame_per_fighter(
             
             //println!("Select = ");
 
-            println!("Brave Status: {}, Work_Int_Decide = {}, Fighter Log Attack Kind (How many frames have fallen at max fall speed?) = {}", status_kind, WorkModule::get_int(module_accessor,*FIGHTER_BRAVE_INSTANCE_WORK_ID_INT_SPECIAL_LW_DECIDE_COMMAND), WorkModule::get_int(module_accessor,*FIGHTER_LOG_DATA_INT_ATTACK_NUM_KIND));
+            //println!("Brave Status: {}, Work_Int_Decide = {}, Fighter Log Attack Kind (How many frames have fallen at max fall speed?) = {}", status_kind, WorkModule::get_int(module_accessor,*FIGHTER_BRAVE_INSTANCE_WORK_ID_INT_SPECIAL_LW_DECIDE_COMMAND), WorkModule::get_int(module_accessor,*FIGHTER_LOG_DATA_INT_ATTACK_NUM_KIND));
             
-            /*
-            if status_kind == 493 { // menu
+            
+            if status_kind == 493 { // menu = 493, dtilt = 44
                 StatusModule::change_status_request_from_script(module_accessor, 497, true);
                 WorkModule::set_int(module_accessor, 10, *FIGHTER_BRAVE_INSTANCE_WORK_ID_INT_SPECIAL_LW_DECIDE_COMMAND); // probably should have this after status? unsure
             }
             if status_kind == 497 { // instant spell, makes nothing happen aside from mp loss
-                StatusModule::change_status_request_from_script(module_accessor, 0, true);
-                WorkModule::unable_transition_term(module_accessor, 44);
+                //StatusModule::change_status_request_from_script(module_accessor, 0, true);
+                //WorkModule::unable_transition_term(module_accessor, 44);
+                //let current_frame = MotionModule::frame(module_accessor);
+                //println!("Current Spell Frame: {}",current_frame);
+                MotionModule::set_rate(module_accessor, 40.0);
             }
-            */
-        }
+            
+        } */
         
 
         input_record::get_command_flag_cat(module_accessor);

--- a/src/training/mod.rs
+++ b/src/training/mod.rs
@@ -14,6 +14,7 @@ pub mod sdi;
 pub mod shield;
 pub mod tech;
 pub mod throw;
+pub mod buff;
 
 mod air_dodge_direction;
 mod attack_angle;

--- a/src/training/mod.rs
+++ b/src/training/mod.rs
@@ -1,4 +1,3 @@
-use crate::is_operation_cpu; // used for debug
 use crate::common::{is_training_mode, menu, FIGHTER_MANAGER_ADDR, STAGE_MANAGER_ADDR};
 use crate::hitbox_visualizer;
 use skyline::nn::hid::*;
@@ -42,7 +41,7 @@ pub unsafe fn handle_check_doyle_summon_dispatch(module_accessor: &mut app::Batt
         return ori;
     }
     if ori == *FIGHTER_JACK_STATUS_KIND_SUMMON as u64 {
-        if buff::is_buffing() {
+        if buff::is_buffing(module_accessor) {
             return 4294967295;
         }
     }

--- a/src/training/mod.rs
+++ b/src/training/mod.rs
@@ -31,19 +31,6 @@ mod reset;
 mod save_states;
 mod shield_tilt;
 
-static FLOAT_OFFSET: usize = 0x4e53C0; // needs updating every patch
-#[skyline::hook(offset = FLOAT_OFFSET)]
-pub unsafe fn get_param_float_hook(work_module: *mut u64, param_object: smash::phx::Hash40, param_name: smash::phx::Hash40) -> f32 {
-    let mut boma = *work_module.add(1) as *mut app::BattleObjectModuleAccessor;
-    // do your checks
-    if param_name == Hash40::new("limit_gauge_add") { //|| param_type == hash40("limit_gauge_add") { // something about param_type being hash for vl.prc? idr
-        println!("Limit Gauge Add! Name");
-        return 500.0;
-    }
-    // This function can/will be used for custom Hero menus in the future
-    original!()(work_module, param_object, param_name)
-}
-
 #[skyline::hook(replace = WorkModule::get_param_float)]
 pub unsafe fn handle_get_param_float(
     module_accessor: &mut app::BattleObjectModuleAccessor,
@@ -127,6 +114,21 @@ fn once_per_frame_per_fighter(
         hitbox_visualizer::get_command_flag_cat(module_accessor);
         save_states::save_states(module_accessor);
         tech::get_command_flag_cat(module_accessor);
+
+        if !is_operation_cpu(module_accessor) {
+            //println!("Cloud Limit Gauge: {}", WorkModule::get_float(module_accessor, *FIGHTER_CLOUD_INSTANCE_WORK_ID_FLOAT_LIMIT_GAUGE));
+            println!("Edge Thresh: {}, Activate: {}, Damage Diff Min: {}, FlagAct'd: {}, FlagEnd: {}, State: {}, Process: {}", 
+                WorkModule::get_float(module_accessor, *FIGHTER_EDGE_INSTANCE_WORK_ID_FLOAT_ONE_WINGED_THRESHOLD_ACTIVATE_POINT),
+                WorkModule::get_float(module_accessor, *FIGHTER_EDGE_INSTANCE_WORK_ID_FLOAT_ONE_WINGED_ACTIVATE_POINT),
+                WorkModule::get_float(module_accessor, *FIGHTER_EDGE_INSTANCE_WORK_ID_FLOAT_ONE_WINGED_DAMAGE_DIFF_MIN),
+                WorkModule::is_flag(module_accessor, *FIGHTER_EDGE_INSTANCE_WORK_ID_FLAG_ONE_WINGED_ACTIVATED),
+                WorkModule::is_flag(module_accessor, *FIGHTER_EDGE_INSTANCE_WORK_ID_FLAG_ONE_WINGED_END_ACTIVATE),
+                WorkModule::get_int(module_accessor, *FIGHTER_EDGE_INSTANCE_WORK_ID_INT_ONE_WINGED_WING_STATE),
+                WorkModule::get_int(module_accessor, *FIGHTER_EDGE_INSTANCE_WORK_ID_INT_ONE_WINGED_PROCESS),
+            );
+
+        }
+
     }
 
     fast_fall::get_command_flag_cat(module_accessor);
@@ -369,7 +371,7 @@ pub fn training_mods() {
         // SDI
         crate::training::sdi::check_hit_stop_delay_command,
         // Buffs
-        get_param_float_hook,
+        //get_param_float_hook,
     );
 
     combo::init();

--- a/src/training/save_states.rs
+++ b/src/training/save_states.rs
@@ -247,6 +247,7 @@ pub unsafe fn save_states(module_accessor: &mut app::BattleObjectModuleAccessor)
         if save_state.state == NoAction {
             set_damage(module_accessor, save_state.percent);
             if fighter_is_buffable {
+                //buff::count_buff_delay();
                 save_state.state = ApplyBuff;
             }
         }
@@ -265,6 +266,7 @@ pub unsafe fn save_states(module_accessor: &mut app::BattleObjectModuleAccessor)
     
     if save_state.state == ApplyBuff { // needs its own save_state.state since this may take multiple frames, want it to loop
         if buff::handle_buffs(module_accessor, fighter_kind, status, save_state.percent) { // returns true when done, will run every frame until then
+            buff::reset_buff_delay(); // set back to 0 whenever we treutrn true above
             save_state.state = NoAction; 
         }
     }

--- a/src/training/save_states.rs
+++ b/src/training/save_states.rs
@@ -18,7 +18,6 @@ enum SaveState {
     PosMove,
     NanaPosMove,
     ApplyBuff,
-    CompleteBuff,
 }
 
 struct SavedState {

--- a/src/training/save_states.rs
+++ b/src/training/save_states.rs
@@ -235,6 +235,24 @@ pub unsafe fn save_states(module_accessor: &mut app::BattleObjectModuleAccessor)
         // if we're done moving, reset percent
         if save_state.state == NoAction {
             set_damage(module_accessor, save_state.percent);
+            /*
+            let fighter_is_brave = fighter_kind == *FIGHTER_KIND_BRAVE;
+            if fighter_is_brave {
+                let status_kind = StatusModule::status_kind(module_accessor) as i32;
+                let prev_status_kind = StatusModule::prev_status_kind(module_accessor, 0);
+                if status_kind == 44 { // dtilt
+                    StatusModule::change_status_request_from_script(module_accessor, 497, true);
+                    WorkModule::set_int(module_accessor, 10, *FIGHTER_BRAVE_INSTANCE_WORK_ID_INT_SPECIAL_LW_DECIDE_COMMAND); // probably should have this after status? unsure
+                }
+                if status_kind == 497 { // instant spell
+                    StatusModule::change_status_request_from_script(module_accessor, 0, true);
+                }
+            }
+            */
+
+
+
+
         }
 
         // if the fighter is Popo, change the state to one where only Nana can move

--- a/src/training/save_states.rs
+++ b/src/training/save_states.rs
@@ -264,7 +264,7 @@ pub unsafe fn save_states(module_accessor: &mut app::BattleObjectModuleAccessor)
     }
     
     if save_state.state == ApplyBuff { // needs its own save_state.state since this may take multiple frames, want it to loop
-        if buff::handle_buffs(module_accessor, fighter_kind, status) { // returns true when done, will run every frame until then
+        if buff::handle_buffs(module_accessor, fighter_kind, status, save_state.percent) { // returns true when done, will run every frame until then
             save_state.state = NoAction; 
         }
     }

--- a/src/training/save_states.rs
+++ b/src/training/save_states.rs
@@ -265,7 +265,7 @@ pub unsafe fn save_states(module_accessor: &mut app::BattleObjectModuleAccessor)
     
     if save_state.state == ApplyBuff { // needs its own save_state.state since this may take multiple frames, want it to loop
         if buff::handle_buffs(module_accessor, fighter_kind, status, save_state.percent) { // returns true when done, will run every frame until then
-            buff::restart_buff(); // set buffing back to false when done
+            buff::restart_buff(module_accessor); // set buffing back to false when done
             save_state.state = NoAction; 
         }
     }

--- a/src/training/save_states.rs
+++ b/src/training/save_states.rs
@@ -247,7 +247,6 @@ pub unsafe fn save_states(module_accessor: &mut app::BattleObjectModuleAccessor)
         if save_state.state == NoAction {
             set_damage(module_accessor, save_state.percent);
             if fighter_is_buffable {
-                //buff::count_buff_delay();
                 save_state.state = ApplyBuff;
             }
         }
@@ -266,7 +265,7 @@ pub unsafe fn save_states(module_accessor: &mut app::BattleObjectModuleAccessor)
     
     if save_state.state == ApplyBuff { // needs its own save_state.state since this may take multiple frames, want it to loop
         if buff::handle_buffs(module_accessor, fighter_kind, status, save_state.percent) { // returns true when done, will run every frame until then
-            buff::reset_buff_delay(); // set back to 0 whenever we treutrn true above
+            buff::restart_buff(); // set buffing back to false when done
             save_state.state = NoAction; 
         }
     }


### PR DESCRIPTION
Adds options for the user to apply buffs to the player and CPU fighters when loading save states. Supported buffs are as follows:

- Hero's Acceleratle
- Hero's Oomph
- Hero's Psyche Up
- Hero's Bounce
- Joker's Arsene
- Wii Fit Trainer's Deep Breathing
- Cloud's Limit Break
- Little Mac's KO Punch
- Sepiroth's One-Winged Angel

Note that Little Mac's KO Punch Gauge UI is not updated when he receives KO Punch in this way until he hits an opponent. Regardless, you can still use KO Punch, and the SFX will still play, so leaving this as a wontfix until I understand the UI updating functions better.