### PR TITLE
Smooth save state

### DIFF
--- a/src/training/mod.rs
+++ b/src/training/mod.rs
@@ -291,6 +291,17 @@ fn params_main(params_info: &ParamsInfo<'_>) {
     }
 }
 
+#[skyline::hook(replace = CameraModule::req_quake)]
+pub unsafe fn handle_req_quake(module_accessor: &mut app::BattleObjectModuleAccessor, my_int: i32) -> u64 {
+    if !is_training_mode() {
+        return original!()(module_accessor,my_int);
+    }
+    if save_states::is_killing() {
+        return original!()(module_accessor, *CAMERA_QUAKE_KIND_NONE);
+    }
+    original!()(module_accessor,my_int)
+}
+
 #[allow(improper_ctypes)]
 extern "C" {
     fn add_nn_hid_hook(callback: fn(*mut NpadHandheldState, *const u32));

--- a/src/training/mod.rs
+++ b/src/training/mod.rs
@@ -281,16 +281,6 @@ pub unsafe fn handle_set_dead_rumble(lua_state: u64) -> u64 {
     original!()(lua_state)
 }
 
-pub static mut COMMON_PARAMS: *mut CommonParams = 0 as *mut _;
-
-fn params_main(params_info: &ParamsInfo<'_>) {
-    if let Ok(common) = params_info.get::<CommonParams>() {
-        unsafe {
-            COMMON_PARAMS = common as *mut _;
-        }
-    }
-}
-
 #[skyline::hook(replace = CameraModule::req_quake)]
 pub unsafe fn handle_req_quake(module_accessor: &mut app::BattleObjectModuleAccessor, my_int: i32) -> u64 {
     if !is_training_mode() {
@@ -300,6 +290,16 @@ pub unsafe fn handle_req_quake(module_accessor: &mut app::BattleObjectModuleAcce
         return original!()(module_accessor, *CAMERA_QUAKE_KIND_NONE);
     }
     original!()(module_accessor,my_int)
+}
+
+pub static mut COMMON_PARAMS: *mut CommonParams = 0 as *mut _;
+
+fn params_main(params_info: &ParamsInfo<'_>) {
+    if let Ok(common) = params_info.get::<CommonParams>() {
+        unsafe {
+            COMMON_PARAMS = common as *mut _;
+        }
+    }
 }
 
 #[allow(improper_ctypes)]
@@ -346,6 +346,7 @@ pub fn training_mods() {
         // Save states
         handle_get_param_int,
         handle_set_dead_rumble,
+        handle_req_quake,
         // Mash attack
         handle_get_attack_air_kind,
         // Attack angle

--- a/src/training/save_states.rs
+++ b/src/training/save_states.rs
@@ -50,6 +50,13 @@ static mut MIRROR_STATE: f32 = 1.0;
 // MIRROR_STATE == 1 -> Do not mirror
 // MIRROR_STATE == -1 -> Do Mirror
 
+pub unsafe fn is_killing() -> bool {
+    if SAVE_STATE_PLAYER.state == KillPlayer || SAVE_STATE_CPU.state == KillPlayer {
+        return true;
+    }
+    return false;
+}
+
 pub unsafe fn should_mirror() -> f32 {
     match MENU.save_state_mirroring {
         SaveStateMirroring::None => 1.0,


### PR DESCRIPTION
Simple change to prevent the screen shake caused by player deaths when loading save states. Much smoother transition than before.