### PR TITLE
Save State Loading Enhancements

### DIFF
--- a/src/training/save_states.rs
+++ b/src/training/save_states.rs
@@ -270,6 +270,16 @@ pub unsafe fn save_states(module_accessor: &mut app::BattleObjectModuleAccessor)
             if fighter_is_buffable {
                 save_state.state = ApplyBuff;
             }
+            // Play Training Reset SFX, since silence is eerie
+            // Only play for the CPU so we don't have 2 overlapping
+            if is_cpu {
+                SoundModule::play_se_no3d(
+                    module_accessor,
+                    Hash40::new("se_system_position_reset"),
+                    true,
+                    true
+                );
+            }
         }
 
         // if the fighter is Popo, change the state to one where only Nana can move


### PR DESCRIPTION
Fixes the issues where different death effects would play during save state loading, even though we try to hide all of them. Also silences the death sound effects when loading save states, and we now play the training mode position reset sound when resetting. Hooking these effect/sound effect functions isn't super costly, as the fighters call different ones during the game. In my testing, the only time I could see the functions I hooked being called were when fighters would die/save states were loaded.