### PR TITLE
Bugfix for shieldgrabs with multiple options selected

### DIFF
--- a/src/training/mash.rs
+++ b/src/training/mash.rs
@@ -152,7 +152,7 @@ fn should_buffer(module_accessor: &mut app::BattleObjectModuleAccessor) -> bool 
 }
 
 // Temp Translation
-pub fn buffer_menu_mash() -> Action {
+pub fn buffer_menu_mash() {
     unsafe {
         let action = MENU.mash_state.get_random();
         buffer_action(action);
@@ -160,8 +160,6 @@ pub fn buffer_menu_mash() -> Action {
         full_hop::roll_full_hop();
         fast_fall::roll_fast_fall();
         FALLING_AERIAL = MENU.falling_aerials.get_random().into_bool();
-
-        action
     }
 }
 

--- a/src/training/shield.rs
+++ b/src/training/shield.rs
@@ -218,7 +218,8 @@ unsafe fn mod_handle_sub_guard_cont(fighter: &mut L2CFighterCommon) {
         return;
     }
 
-    let action = mash::buffer_menu_mash();
+    mash::buffer_menu_mash();
+    let action = mash::get_current_buffer();
 
     if handle_escape_option(fighter, module_accessor) {
         return;


### PR DESCRIPTION
When multiple mash options are selected, shieldgrabs will no longer go through the shielddrop animation before grabbing. Fixes #241 .