### PR TITLE
Version check for v3.3

### DIFF
--- a/src/common/release.rs
+++ b/src/common/release.rs
@@ -4,15 +4,23 @@ use std::fs;
 pub const CURRENT_VERSION: &str = env!("CARGO_PKG_VERSION");
 const VERSION_FILE_PATH: &str = "sd:/TrainingModpack/version.txt";
 
-fn is_current_version(fpath: &str) -> bool {
+fn is_current_version(fpath: &str) -> Option<bool> {
+    // Returns:
+    //     Some(true) if it is the current version
+    //     Some(false) if it is upgrading from a prior version
+    //     None if it is a fresh install (i.e. no prior version.txt exists)
+
     // Create a blank version file if it doesn't exists
     if fs::metadata(fpath).is_err() {
-        let _ = fs::File::create(fpath).expect("Could not create version file!");
+        fs::File::create(fpath).expect("Could not create version file!");
+        return None;
     }
 
-    fs::read_to_string(fpath)
-        .map(|content| content == CURRENT_VERSION)
-        .unwrap_or(false)
+    Some(
+        fs::read_to_string(fpath)
+            .map(|content| content == CURRENT_VERSION)
+            .unwrap_or(false),
+    )
 }
 
 fn record_current_version(fpath: &str) {
@@ -21,16 +29,36 @@ fn record_current_version(fpath: &str) {
 }
 
 pub fn version_check() {
-    // Display dialog box on launch if changing versions
-    if !is_current_version(VERSION_FILE_PATH) {
-        DialogOk::ok(
-            format!(
-                "Thank you for installing version {} of the Training Modpack.\n\n\
-                This version includes a change to the menu button combination, which is now SPECIAL+UPTAUNT.\n\
-                Please refer to the Github page and the Discord server for a full list of recent changes.",
-                CURRENT_VERSION
-            )
-        );
-        record_current_version(VERSION_FILE_PATH);
+    match is_current_version(VERSION_FILE_PATH) {
+        Some(true) => {
+            // Version is current, no need to take any action
+        }
+        Some(false) => {
+            // Display dialog box on launch if changing versions
+            DialogOk::ok(
+                format!(
+                    "Thank you for installing version {} of the Training Modpack.\n\n\
+                    Due to a breaking change in this version, your menu selections and defaults must be reset once.\n\n\
+                    Please refer to the Github page and the Discord server for a full list of recent features, bugfixes, and other changes.",
+                    CURRENT_VERSION
+                )
+            );
+            // Remove old menu selections, silently ignoring errors (i.e. if the file doesn't exist)
+            fs::remove_file("sd:/TrainingModpack/training_modpack_menu.conf").unwrap_or({});
+            fs::remove_file("sd:/TrainingModpack/training_modpack_menu_defaults.conf")
+                .unwrap_or({});
+            record_current_version(VERSION_FILE_PATH);
+        }
+        None => {
+            // Display dialog box on fresh installation
+            DialogOk::ok(
+                format!(
+                    "Thank you for installing version {} of the Training Modpack.\n\n\
+                    Please refer to the Github page and the Discord server for a full list of features and instructions on how to utilize the improved Training Mode.",
+                    CURRENT_VERSION
+                )
+            );
+            record_current_version(VERSION_FILE_PATH);
+        }
     }
 }


### PR DESCRIPTION
Removes old `.conf` files on upgrade to account for url schema changes. Displays a different dialog box for new installations than upgrades.