### PR TITLE
Fix input delay getting passed to url params incorrectly

### DIFF
--- a/training_mod_consts/src/lib.rs
+++ b/training_mod_consts/src/lib.rs
@@ -912,9 +912,11 @@ trait ToUrlParam {
     fn to_url_param(&self) -> String;
 }
 
+// The i32 is now in log form, need to exponentiate
+// back into 2^X when we pass back to the menu
 impl ToUrlParam for i32 {
     fn to_url_param(&self) -> String {
-        self.to_string()
+        2_i32.pow(*self as u32).to_string()
     }
 }
 


### PR DESCRIPTION
The web menu considers all selections to have values which are powers of 2. When exporting from the menu, we call log_2 to convert from 2^X -> X. However, when passing values into the menu we didn't convert from X -> 2^X. This caused the input delay to be displayed incorrectly. Resolves #360 .