### PR TITLE
Add Crouch Setting

### DIFF
--- a/src/static/img/crouch.svg
+++ b/src/static/img/crouch.svg
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="80.0px"
+   height="80.0px"
+   viewBox="0 0 80.0 80.0"
+   version="1.1"
+   id="SVGRoot"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs833" />
+  <metadata
+     id="metadata836">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer2">
+    <ellipse
+       style="fill:none;stroke:#ffffff;stroke-width:4.24602;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path968"
+       cx="38.602196"
+       cy="50.794861"
+       rx="34.14621"
+       ry="16.46673" />
+    <path
+       style="fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 5.136058,56.48855 C 0.03773872,68.258842 8.944851,70.078439 20.219251,64.298879"
+       id="path1303" />
+    <path
+       style="fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 38.814677,67.325204 C 54.984065,80.11361 6.3280294,79.05744 8.2170673,67.234064"
+       id="path1946" />
+    <path
+       style="fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 65.857881,60.569742 C 80.617048,72.270636 63.691207,76.1483 47.455415,67.501231"
+       id="path2599" />
+    <ellipse
+       style="fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path3212"
+       cx="16.421764"
+       cy="67.510216"
+       rx="3.8247013"
+       ry="5.4183269"
+       transform="rotate(-27.25411)" />
+    <ellipse
+       style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path3442"
+       cx="34.510593"
+       cy="59.416187"
+       rx="5.8964143"
+       ry="1.5936255" />
+    <ellipse
+       style="fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path3546"
+       cx="55.952282"
+       cy="66.090828"
+       rx="2.1779549"
+       ry="0.90305448"
+       transform="rotate(-10.763148)" />
+    <path
+       style="fill:none;stroke:#fffffb;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 73.208558,52.361585 c 7.669126,3.971723 3.747746,13.195461 -7.350677,8.208157"
+       id="path3803" />
+    <circle
+       style="fill:#ffffff;fill-opacity:1;stroke:#fffffb;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path4490"
+       cx="44.548664"
+       cy="50.145424"
+       r="2.2912889" />
+    <ellipse
+       style="fill:none;stroke:#ffffff;stroke-width:1.86442;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path3212-7"
+       cx="33.601746"
+       cy="74.975929"
+       rx="3.3859093"
+       ry="5.3188171"
+       transform="matrix(0.85133369,-0.52462458,0.39549414,0.9184685,0,0)" />
+    <ellipse
+       style="fill:#ffffff;fill-opacity:1;stroke:#fffffb;stroke-width:1.85452;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path4490-4"
+       cx="57.440308"
+       cy="48.851425"
+       rx="1.9425105"
+       ry="2.323806" />
+  </g>
+</svg>

--- a/src/training/crouch.rs
+++ b/src/training/crouch.rs
@@ -1,0 +1,27 @@
+use crate::common::consts::OnOff;
+use crate::common::*;
+use smash::app::{lua_bind::StatusModule, BattleObjectModuleAccessor};
+use smash::lib::lua_const::*;
+
+pub unsafe fn mod_get_stick_y(module_accessor: &mut BattleObjectModuleAccessor) -> Option<f32> {
+    if !is_operation_cpu(module_accessor) {
+        return None;
+    }
+    let fighter_status_kind = StatusModule::status_kind(module_accessor);
+
+    if MENU.crouch == OnOff::On
+        && [
+            *FIGHTER_STATUS_KIND_WAIT,
+            *FIGHTER_STATUS_KIND_SQUAT,
+            *FIGHTER_STATUS_KIND_SQUAT_B,
+            *FIGHTER_STATUS_KIND_SQUAT_F,
+            *FIGHTER_STATUS_KIND_SQUAT_RV,
+            *FIGHTER_STATUS_KIND_SQUAT_WAIT,
+        ]
+        .contains(&fighter_status_kind)
+    {
+        Some(-1.0)
+    } else {
+        None
+    }
+}

--- a/src/training/mod.rs
+++ b/src/training/mod.rs
@@ -15,6 +15,7 @@ pub mod buff;
 pub mod charge;
 pub mod clatter;
 pub mod combo;
+pub mod crouch;
 pub mod directional_influence;
 pub mod frame_counter;
 pub mod ledge;
@@ -189,7 +190,9 @@ pub unsafe fn get_stick_dir(module_accessor: &mut app::BattleObjectModuleAccesso
 }
 
 /**
- *
+ * Called when:
+ * Directional airdodge
+ * Crouching
  */
 #[skyline::hook(replace = ControlModule::get_stick_y)]
 pub unsafe fn get_stick_y(module_accessor: &mut app::BattleObjectModuleAccessor) -> f32 {
@@ -198,7 +201,8 @@ pub unsafe fn get_stick_y(module_accessor: &mut app::BattleObjectModuleAccessor)
         return ori;
     }
 
-    air_dodge_direction::mod_get_stick_y(module_accessor).unwrap_or(ori)
+    air_dodge_direction::mod_get_stick_y(module_accessor)
+        .unwrap_or_else(|| crouch::mod_get_stick_y(module_accessor).unwrap_or(ori))
 }
 
 #[skyline::hook(replace = ControlModule::check_button_on)]

--- a/training_mod_consts/src/lib.rs
+++ b/training_mod_consts/src/lib.rs
@@ -1049,6 +1049,7 @@ url_params! {
         pub falling_aerials: BoolFlag,
         pub aerial_delay: Delay,
         pub full_hop: BoolFlag,
+        pub crouch: OnOff,
         pub input_delay: i32,
         pub save_damage: OnOff,
         pub save_state_mirroring: SaveStateMirroring,
@@ -1092,6 +1093,7 @@ impl TrainingModpackMenu {
             air_dodge_dir = Direction::from_bits(val),
             attack_angle = AttackAngle::from_bits(val),
             clatter_strength = num::FromPrimitive::from_u32(val),
+            crouch = OnOff::from_val(val),
             defensive_state = Defensive::from_bits(val),
             di_state = Direction::from_bits(val),
             falling_aerials = BoolFlag::from_bits(val),
@@ -1179,6 +1181,7 @@ pub static DEFAULTS_MENU: TrainingModpackMenu = TrainingModpackMenu {
     falling_aerials: BoolFlag::empty(),
     aerial_delay: Delay::empty(),
     full_hop: BoolFlag::empty(),
+    crouch: OnOff::Off,
     input_delay: 0,
     save_damage: OnOff::On,
     save_state_mirroring: SaveStateMirroring::None,
@@ -1505,6 +1508,12 @@ pub unsafe fn get_menu() -> UiMenu<'static> {
         "Character Item",
         "character_item",
         "Character Item: CPU/Player item to hold when loading a save state",
+        true
+    );
+    defensive_tab.add_submenu_with_toggles::<OnOff>(
+        "Crouch",
+        "crouch",
+        "Crouch: Should the CPU crouch when on the ground",
         true
     );
     overall_menu.tabs.push(defensive_tab);


### PR DESCRIPTION
Adds a menu setting under the defensive tab to control CPU crouch behavior. When set to On, the CPU crouches when on the ground and not busy with other animations. When set to Off, the CPU behavior is normal.

I did try using StatusModule::change_status_request_from_script and the various FIGHTER_STATUS_KIND_SQUAT statuses but didn't find a way to make them hold the crouch. Hooking the get_stick_y function turned out to be much easier.