### PR TITLE
Make ganon's aerial sideb untechable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ bitflags = "1.2.1"
 parking_lot = { version = "0.12.0", features = ["nightly"] }
 lazy_static = "1.4.0"
 owo-colors = "2.1.0"
+once_cell = "1.12.0"
 ramhorns = "0.12.0"
 paste = "1.0"
 num = "0.4.0"

--- a/src/common/events.rs
+++ b/src/common/events.rs
@@ -1,4 +1,4 @@
-use core::lazy::OnceCell;
+use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
 use skyline::libc::c_void;
 use skyline::nn::{account, crypto, oe, time};

--- a/src/training/tech.rs
+++ b/src/training/tech.rs
@@ -67,10 +67,16 @@ fn handle_grnd_tech(
     }
 
     unsafe {
+        // prev_status_kind(module_accessor, 0) gets the 1st previous status,
+        // which is FIGHTER_STATUS_KIND_CATCHED_AIR_END_GANON for both aerial/grounded sideb
+        // prev_status_kind(module_accessor, 1) gets the 2nd previous status,
+        // which is FIGHTER_STATUS_KIND_CATCHED_GANON for grounded sideb
+        // and FIGHTER_STATUS_KIND_CATCHED_AIR_GANON for aerial sideb
+        let second_prev_status = StatusModule::prev_status_kind(module_accessor, 1);
         let can_tech = WorkModule::is_enable_transition_term(
             module_accessor,
             *FIGHTER_STATUS_TRANSITION_TERM_ID_PASSIVE,
-        );
+        ) && (second_prev_status != FIGHTER_STATUS_KIND_CATCHED_AIR_FALL_GANON);
 
         if !can_tech {
             return false;


### PR DESCRIPTION
Resolves #217 

Checks for the 2nd previous status to see if the CPU was in FIGHTER_STATUS_KIND_CATCHED_AIR_GANON. For grounded sideb, the 2nd previous status is FIGHTER_STATUS_KIND_CATCHED_GANON.