### PR TITLE
Refactor to use Web Sessions

### DIFF
--- a/src/common/menu.rs
+++ b/src/common/menu.rs
@@ -407,10 +407,10 @@ pub unsafe fn web_session_loop() {
                     session.show();
                     let message = session.recv();
                     println!("[Training Modpack] Received menu from web:\n{}", &message);
-                    set_menu_from_json(&message);
                     session.exit();
                     session.wait_for_exit();
                     web_session = None;
+                    set_menu_from_json(&message);
                     SHOULD_SHOW_MENU = false;
                 }
             } else {

--- a/src/common/menu.rs
+++ b/src/common/menu.rs
@@ -389,20 +389,21 @@ pub unsafe fn web_session_loop() {
     loop {
         std::thread::sleep(std::time::Duration::from_millis(100));
         if is_training_mode() {
-            if SHOULD_SHOW_MENU && web_session.is_some() {
-                println!("[Training Modpack] Opening session...");
-                let session = web_session.unwrap();
-                session.show();
-                let message = session.recv();
-                println!("[Training Modpack] Received menu from web:\n{}", message);
-                set_menu_from_url(&message);
-                session.wait_for_exit();
-                session.exit();
-                web_session = None;
-                SHOULD_SHOW_MENU = false;
-            }
-            if web_session.is_none() {
-                println!("[Training Modpack] Starting new session...");
+            if web_session.is_some() {
+                if SHOULD_SHOW_MENU {
+                    println!("[Training Modpack] Opening menu session...");
+                    let session = web_session.unwrap();
+                    session.show();
+                    let message = session.recv();
+                    println!("[Training Modpack] Received menu from web:\n{}", message);
+                    set_menu_from_url(&message);
+                    session.wait_for_exit();
+                    session.exit();
+                    web_session = None;
+                    SHOULD_SHOW_MENU = false;
+                }
+            } else {
+                println!("[Training Modpack] Starting new menu session...");
                 let (params, default_params);
                 params = MENU.to_url_params(false);
                 default_params = DEFAULTS_MENU.to_url_params(true);

--- a/src/common/menu.rs
+++ b/src/common/menu.rs
@@ -76,6 +76,8 @@ pub unsafe fn write_menu() {
 const MENU_CONF_PATH: &str = "sd:/TrainingModpack/training_modpack_menu.conf";
 
 pub fn set_menu_from_url(last_url: &str) {
+    // TODO: Remove this function
+    // Or maybe keep it in for compatibility with existing settings files upon upgrade?
     unsafe {
         MENU = get_menu_from_url(MENU, last_url, false);
         DEFAULTS_MENU = get_menu_from_url(MENU, last_url, true);
@@ -96,6 +98,10 @@ pub fn set_menu_from_url(last_url: &str) {
     unsafe {
         EVENT_QUEUE.push(Event::menu_open(last_url.to_string()));
     }
+}
+
+pub fn set_menu_from_json(message: &str) {
+    // stub
 }
 
 pub fn spawn_menu() {
@@ -300,7 +306,7 @@ pub unsafe fn quick_menu_loop() {
                 {
                     // Leave menu.
                     menu::QUICK_MENU_ACTIVE = false;
-                    menu::set_menu_from_url(url.as_str());
+                    menu::set_menu_from_url(url.as_str()); // TODO update to json
                     println!("URL: {}", url.as_str());
                 }
             });
@@ -394,9 +400,9 @@ pub unsafe fn web_session_loop() {
                     println!("[Training Modpack] Opening menu session...");
                     let session = web_session.unwrap();
                     session.show();
-                    let message = session.recv();
+                    let message = session.recv_json();
                     println!("[Training Modpack] Received menu from web:\n{}", message);
-                    set_menu_from_url(&message);
+                    set_menu_from_json(&message);
                     session.wait_for_exit();
                     session.exit();
                     web_session = None;

--- a/src/common/menu.rs
+++ b/src/common/menu.rs
@@ -408,8 +408,8 @@ pub unsafe fn web_session_loop() {
                     let message = session.recv();
                     println!("[Training Modpack] Received menu from web:\n{}", &message);
                     set_menu_from_json(&message);
-                    session.wait_for_exit();
                     session.exit();
+                    session.wait_for_exit();
                     web_session = None;
                     SHOULD_SHOW_MENU = false;
                 }

--- a/src/common/menu.rs
+++ b/src/common/menu.rs
@@ -404,36 +404,36 @@ pub unsafe fn web_session_loop() {
                 if SHOULD_SHOW_MENU {
                     println!("[Training Modpack] Opening menu session...");
                     let session = web_session.unwrap();
+                    let message_send = WebAppletResponse {
+                        menu: MENU,
+                        defaults_menu: DEFAULTS_MENU
+                    };
+                    session.send_json(&message_send);
+                    println!("[Training Modpack] Sending message:\n{}", serde_json::to_string_pretty(&message_send).unwrap());
                     session.show();
-                    let message = session.recv();
-                    println!("[Training Modpack] Received menu from web:\n{}", &message);
+                    let message_recv = session.recv();
+                    println!("[Training Modpack] Received menu from web:\n{}", &message_recv);
+                    println!("[Training Modpack] Tearing down Training Modpack menu session");
                     session.exit();
                     session.wait_for_exit();
                     web_session = None;
-                    set_menu_from_json(&message);
+                    set_menu_from_json(&message_recv);
                     SHOULD_SHOW_MENU = false;
                 }
             } else {
                 println!("[Training Modpack] Starting new menu session...");
-                let (params, default_params);
-                params = MENU.to_url_params(false);
-                default_params = DEFAULTS_MENU.to_url_params(true);
-                println!(
-                    "serialized menu:\n{}",
-                    serde_json::to_string_pretty(&MENU).unwrap()
-                );
                 web_session = Some(
                     Webpage::new()
                         .background(Background::BlurredScreenshot)
                         .htdocs_dir("training_modpack")
-                        .boot_display(BootDisplay::BlurredScreenshot)
-                        .boot_icon(true)
-                        .start_page(&format!("{}?{}&{}", "training_menu.html", params, default_params))
+                        .start_page("training_menu.html")
                         .open_session(WebSessionBootMode::InitiallyHidden)
                         .unwrap(),
                 );
+
             }
         } else {
+            // This isn't working...I think that is_training_mode() isn't becoming false once the training match exits.
             if web_session.is_some() {
                 println!("[Training Modpack] Tearing down Training Modpack menu session");
                 web_session.unwrap().exit();

--- a/src/common/menu.rs
+++ b/src/common/menu.rs
@@ -8,7 +8,7 @@ use ramhorns::Template;
 use skyline::info::get_program_id;
 use skyline::nn::hid::NpadGcState;
 use skyline::nn::web::WebSessionBootMode;
-use skyline_web::{Background, BootDisplay, WebSession, Webpage};
+use skyline_web::{Background, WebSession, Webpage};
 use smash::lib::lua_const::*;
 use std::fs;
 use std::path::Path;
@@ -104,6 +104,8 @@ pub unsafe fn set_menu_from_json(message: &str) {
     if let Ok(message_json) = serde_json::from_str::<WebAppletResponse>(message) {
         MENU = message_json.menu;
         DEFAULTS_MENU = message_json.defaults_menu;
+        std::fs::write(MENU_CONF_PATH, serde_json::to_string_pretty(&message_json).unwrap()).expect("Failed to write menu conf file");
+        // EVENT_QUEUE.push(Event::menu_open(menus_json.to_string())); // TODO
     } else {
         panic!("Could not read the menu response!\n{}", message);
     };

--- a/src/common/menu.rs
+++ b/src/common/menu.rs
@@ -3,18 +3,18 @@ use crate::common::*;
 use crate::events::{Event, EVENT_QUEUE};
 use crate::training::frame_counter;
 
+use owo_colors::OwoColorize;
 use parking_lot::Mutex;
 use ramhorns::Template;
 use skyline::info::get_program_id;
-use skyline_web::{Background, BootDisplay, Webpage, WebSession};
 use skyline::nn::hid::NpadGcState;
 use skyline::nn::web::WebSessionBootMode;
+use skyline_web::{Background, BootDisplay, WebSession, Webpage};
 use smash::lib::lua_const::*;
 use std::fs;
 use std::path::Path;
 use std::time::{SystemTime, UNIX_EPOCH};
 use training_mod_tui::Color;
-use owo_colors::OwoColorize;
 
 static mut FRAME_COUNTER_INDEX: usize = 0;
 pub static mut QUICK_MENU_FRAME_COUNTER_INDEX: usize = 0;
@@ -276,7 +276,7 @@ pub fn render_text_to_screen(s: &str) {
 pub unsafe fn quick_menu_loop() {
     loop {
         std::thread::sleep(std::time::Duration::from_secs(10));
-        let menu= consts::get_menu();
+        let menu = consts::get_menu();
 
         let mut app = training_mod_tui::App::new(menu);
 
@@ -298,8 +298,7 @@ pub unsafe fn quick_menu_loop() {
                 received_input = true;
                 if !app.outer_list {
                     app.on_b()
-                } else if frame_counter::get_frame_count(menu::QUICK_MENU_FRAME_COUNTER_INDEX)
-                    == 0
+                } else if frame_counter::get_frame_count(menu::QUICK_MENU_FRAME_COUNTER_INDEX) == 0
                 {
                     // Leave menu.
                     menu::QUICK_MENU_ACTIVE = false;
@@ -372,7 +371,7 @@ pub unsafe fn quick_menu_loop() {
                     }
                     _ => write!(&mut view, "{}", &cell.symbol),
                 }
-                    .unwrap();
+                .unwrap();
                 if i % frame_res.area.width as usize == frame_res.area.width as usize - 1 {
                     writeln!(&mut view).unwrap();
                 }
@@ -388,7 +387,7 @@ pub unsafe fn quick_menu_loop() {
 static mut SHOULD_SHOW_MENU: bool = false;
 
 pub unsafe fn web_session_loop() {
-    let mut web_session : Option<WebSession> = None;
+    let mut web_session: Option<WebSession> = None;
     loop {
         std::thread::sleep(std::time::Duration::from_millis(100));
 
@@ -412,14 +411,16 @@ pub unsafe fn web_session_loop() {
                 default_params = DEFAULTS_MENU.to_url_params(true);
             }
 
-            web_session = Some(Webpage::new()
-                .background(Background::BlurredScreenshot)
-                .htdocs_dir("training_modpack")
-                .boot_display(BootDisplay::BlurredScreenshot)
-                .boot_icon(true)
-                .start_page(&format!("{}?{}&{}", "index.html", params, default_params))
-                .open_session(WebSessionBootMode::InitiallyHidden)
-                .unwrap());
+            web_session = Some(
+                Webpage::new()
+                    .background(Background::BlurredScreenshot)
+                    .htdocs_dir("training_modpack")
+                    .boot_display(BootDisplay::BlurredScreenshot)
+                    .boot_icon(true)
+                    .start_page(&format!("{}?{}&{}", "index.html", params, default_params))
+                    .open_session(WebSessionBootMode::InitiallyHidden)
+                    .unwrap(),
+            );
         }
     }
 }

--- a/src/common/menu.rs
+++ b/src/common/menu.rs
@@ -428,7 +428,7 @@ pub unsafe fn web_session_loop() {
                         .htdocs_dir("training_modpack")
                         .boot_display(BootDisplay::BlurredScreenshot)
                         .boot_icon(true)
-                        .start_page(&format!("{}?{}&{}", "index.html", params, default_params))
+                        .start_page(&format!("{}?{}&{}", "training_menu.html", params, default_params))
                         .open_session(WebSessionBootMode::InitiallyHidden)
                         .unwrap(),
                 );

--- a/src/common/menu.rs
+++ b/src/common/menu.rs
@@ -398,10 +398,12 @@ pub unsafe fn quick_menu_loop() {
 static mut SHOULD_SHOW_MENU: bool = false;
 
 pub unsafe fn web_session_loop() {
+    // Don't query the fightermanager too early otherwise it will crash...
+    std::thread::sleep(std::time::Duration::new(30, 0)); // sleep for 30 secs on bootup
     let mut web_session: Option<WebSession> = None;
     loop {
         std::thread::sleep(std::time::Duration::from_millis(100));
-        if is_training_mode() {
+        if is_ready_go() & is_training_mode() {
             if web_session.is_some() {
                 if SHOULD_SHOW_MENU {
                     println!("[Training Modpack] Opening menu session...");
@@ -435,7 +437,8 @@ pub unsafe fn web_session_loop() {
 
             }
         } else {
-            // This isn't working...I think that is_training_mode() isn't becoming false once the training match exits.
+            // No longer in training mode, tear down the session to avoid conflicts with other web plugins
+            // Having the session open too long, especially if the switch has been put to sleep, can cause freezes
             if web_session.is_some() {
                 println!("[Training Modpack] Tearing down Training Modpack menu session");
                 web_session.unwrap().exit();

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -141,3 +141,8 @@ pub unsafe fn is_dead(module_accessor: &mut app::BattleObjectModuleAccessor) -> 
 pub unsafe fn is_in_clatter(module_accessor: &mut app::BattleObjectModuleAccessor) -> bool {
     ControlModule::get_clatter_time(module_accessor, 0) > 0.0
 }
+
+pub unsafe fn is_ready_go() -> bool {
+    let fighter_manager = *(FIGHTER_MANAGER_ADDR as *mut *mut app::FighterManager);
+    FighterManager::is_ready_go(fighter_manager)
+}

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -142,6 +142,7 @@ pub unsafe fn is_in_clatter(module_accessor: &mut app::BattleObjectModuleAccesso
     ControlModule::get_clatter_time(module_accessor, 0) > 0.0
 }
 
+// Returns true if a match is currently active
 pub unsafe fn is_ready_go() -> bool {
     let fighter_manager = *(FIGHTER_MANAGER_ADDR as *mut *mut app::FighterManager);
     FighterManager::is_ready_go(fighter_manager)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,7 @@ use crate::training::frame_counter;
 use owo_colors::OwoColorize;
 use training_mod_consts::OnOff;
 use training_mod_tui::Color;
+use crate::menu::{quick_menu_loop, web_session_loop};
 
 fn nro_main(nro: &NroInfo<'_>) {
     if nro.module.isLoaded {
@@ -46,24 +47,10 @@ fn nro_main(nro: &NroInfo<'_>) {
     }
 }
 
-extern "C" {
-    #[link_name = "render_text_to_screen"]
-    pub fn render_text_to_screen_cstr(str: *const c_char);
-
-    #[link_name = "set_should_display_text_to_screen"]
-    pub fn set_should_display_text_to_screen(toggle: bool);
-}
-
 macro_rules! c_str {
     ($l:tt) => {
         [$l.as_bytes(), "\u{0}".as_bytes()].concat().as_ptr()
     };
-}
-
-pub fn render_text_to_screen(s: &str) {
-    unsafe {
-        render_text_to_screen_cstr(c_str!(s));
-    }
 }
 
 #[skyline::main(name = "training_modpack")]
@@ -142,117 +129,14 @@ pub fn main() {
     });
 
     std::thread::spawn(|| {
-        std::thread::sleep(std::time::Duration::from_secs(10));
-        let menu;
         unsafe {
-            menu = consts::get_menu();
+            quick_menu_loop()
         }
+    });
 
-        let mut app = training_mod_tui::App::new(menu);
-
-        let backend = training_mod_tui::TestBackend::new(75, 15);
-        let mut terminal = training_mod_tui::Terminal::new(backend).unwrap();
-
+    std::thread::spawn(|| {
         unsafe {
-            let mut has_slept_millis = 0;
-            let render_frames = 5;
-            let mut url = String::new();
-            let button_presses = &mut menu::BUTTON_PRESSES;
-            let mut received_input = true;
-            loop {
-                button_presses.a.read_press().then(|| {
-                    app.on_a();
-                    received_input = true;
-                });
-                let b_press = &mut button_presses.b;
-                b_press.read_press().then(|| {
-                    received_input = true;
-                    if !app.outer_list {
-                        app.on_b()
-                    } else if frame_counter::get_frame_count(menu::QUICK_MENU_FRAME_COUNTER_INDEX)
-                        == 0
-                    {
-                        // Leave menu.
-                        menu::QUICK_MENU_ACTIVE = false;
-                        menu::set_menu_from_url(url.as_str());
-                        println!("URL: {}", url.as_str());
-                    }
-                });
-                button_presses.zl.read_press().then(|| {
-                    app.on_l();
-                    received_input = true;
-                });
-                button_presses.zr.read_press().then(|| {
-                    app.on_r();
-                    received_input = true;
-                });
-                button_presses.left.read_press().then(|| {
-                    app.on_left();
-                    received_input = true;
-                });
-                button_presses.right.read_press().then(|| {
-                    app.on_right();
-                    received_input = true;
-                });
-                button_presses.up.read_press().then(|| {
-                    app.on_up();
-                    received_input = true;
-                });
-                button_presses.down.read_press().then(|| {
-                    app.on_down();
-                    received_input = true;
-                });
-
-                std::thread::sleep(std::time::Duration::from_millis(16));
-                has_slept_millis += 16;
-                if has_slept_millis < 16 * render_frames {
-                    continue;
-                }
-                has_slept_millis = 16;
-                if !menu::QUICK_MENU_ACTIVE {
-                    app = training_mod_tui::App::new(consts::get_menu());
-                    set_should_display_text_to_screen(false);
-                    continue;
-                }
-                if !received_input {
-                    continue;
-                }
-                let mut view = String::new();
-
-                let frame_res = terminal
-                    .draw(|f| url = training_mod_tui::ui(f, &mut app))
-                    .unwrap();
-
-                use std::fmt::Write;
-                for (i, cell) in frame_res.buffer.content().iter().enumerate() {
-                    match cell.fg {
-                        Color::Black => write!(&mut view, "{}", &cell.symbol.black()),
-                        Color::Blue => write!(&mut view, "{}", &cell.symbol.blue()),
-                        Color::LightBlue => write!(&mut view, "{}", &cell.symbol.bright_blue()),
-                        Color::Cyan => write!(&mut view, "{}", &cell.symbol.cyan()),
-                        Color::LightCyan => write!(&mut view, "{}", &cell.symbol.cyan()),
-                        Color::Red => write!(&mut view, "{}", &cell.symbol.red()),
-                        Color::LightRed => write!(&mut view, "{}", &cell.symbol.bright_red()),
-                        Color::LightGreen => write!(&mut view, "{}", &cell.symbol.bright_green()),
-                        Color::Green => write!(&mut view, "{}", &cell.symbol.green()),
-                        Color::Yellow => write!(&mut view, "{}", &cell.symbol.yellow()),
-                        Color::LightYellow => write!(&mut view, "{}", &cell.symbol.bright_yellow()),
-                        Color::Magenta => write!(&mut view, "{}", &cell.symbol.magenta()),
-                        Color::LightMagenta => {
-                            write!(&mut view, "{}", &cell.symbol.bright_magenta())
-                        }
-                        _ => write!(&mut view, "{}", &cell.symbol),
-                    }
-                    .unwrap();
-                    if i % frame_res.area.width as usize == frame_res.area.width as usize - 1 {
-                        writeln!(&mut view).unwrap();
-                    }
-                }
-                writeln!(&mut view).unwrap();
-
-                render_text_to_screen(view.as_str());
-                received_input = false;
-            }
+            web_session_loop()
         }
     });
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@ use std::fs;
 
 use crate::menu::{quick_menu_loop, web_session_loop};
 use owo_colors::OwoColorize;
-use training_mod_consts::{OnOff, WebAppletResponse};
+use training_mod_consts::{OnOff, MenuJsonStruct};
 
 fn nro_main(nro: &NroInfo<'_>) {
     if nro.module.isLoaded {
@@ -85,7 +85,7 @@ pub fn main() {
     log!("Checking for previous menu in training_modpack_menu.conf...");
     if fs::metadata(menu_conf_path).is_ok() {
         let menu_conf = fs::read_to_string(&menu_conf_path).unwrap();
-        if let Ok(menu_conf_json) = serde_json::from_str::<WebAppletResponse>(&menu_conf) {
+        if let Ok(menu_conf_json) = serde_json::from_str::<MenuJsonStruct>(&menu_conf) {
             unsafe {
                 MENU = menu_conf_json.menu;
                 DEFAULTS_MENU = menu_conf_json.defaults_menu;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,11 +27,11 @@ use skyline::libc::{c_char, mkdir};
 use skyline::nro::{self, NroInfo};
 use std::fs;
 
+use crate::menu::{quick_menu_loop, web_session_loop};
 use crate::training::frame_counter;
 use owo_colors::OwoColorize;
 use training_mod_consts::OnOff;
 use training_mod_tui::Color;
-use crate::menu::{quick_menu_loop, web_session_loop};
 
 fn nro_main(nro: &NroInfo<'_>) {
     if nro.module.isLoaded {
@@ -128,15 +128,7 @@ pub fn main() {
         }
     });
 
-    std::thread::spawn(|| {
-        unsafe {
-            quick_menu_loop()
-        }
-    });
+    std::thread::spawn(|| unsafe { quick_menu_loop() });
 
-    std::thread::spawn(|| {
-        unsafe {
-            web_session_loop()
-        }
-    });
+    std::thread::spawn(|| unsafe { web_session_loop() });
 }

--- a/src/static/js/training_modpack.js
+++ b/src/static/js/training_modpack.js
@@ -182,12 +182,10 @@ function playSound(label) {
 const exit = () => {
     playSound('SeFooterDecideBack');
 
-
     if (isNx) {
         window.nx.sendMessage(
             JSON.stringify(settings)
         );
-        window.nx.endApplet()
     } else {
         console.log(JSON.stringify(settings));
     }

--- a/src/static/js/training_modpack.js
+++ b/src/static/js/training_modpack.js
@@ -186,8 +186,10 @@ const exit = () => {
 
 
     if (isNx) {
-        window.nx.sendMessage(url);
-        window.location.href = url;
+        window.nx.sendMessage(
+            JSON.stringify(settings)
+        );
+        window.nx.endApplet()
     } else {
         console.log(url);
     }

--- a/src/static/js/training_modpack.js
+++ b/src/static/js/training_modpack.js
@@ -42,7 +42,7 @@ if (isNx) {
                 break;
             case 'l':
                 console.log('l');
-                resetAllSubmenus();
+                resetAllMenus();
                 break;
             case 'r':
                 console.log('r');
@@ -182,8 +182,6 @@ function playSound(label) {
 const exit = () => {
     playSound('SeFooterDecideBack');
 
-    const url = buildURLFromSettings();
-
 
     if (isNx) {
         window.nx.sendMessage(
@@ -191,7 +189,7 @@ const exit = () => {
         );
         window.nx.endApplet()
     } else {
-        console.log(url);
+        console.log(JSON.stringify(settings));
     }
 };
 

--- a/src/static/js/training_modpack.js
+++ b/src/static/js/training_modpack.js
@@ -29,6 +29,7 @@ if (isNx) {
     window.nx.footer.setAssign('R', '', saveDefaults, { se: '' });
     window.nx.footer.setAssign('ZR', '', cycleNextTab, { se: '' });
     window.nx.footer.setAssign('ZL', '', cyclePrevTab, { se: '' });
+    window.nx.addEventListener("message", function(msg) { setSettingsFromJSON(msg)});
 } else {
     document.addEventListener('keypress', (event) => {
         switch (event.key) {
@@ -63,10 +64,6 @@ if (isNx) {
 const onLoad = () => {
     // Activate the first tab
     openTab(document.querySelector('button.tab-button'));
-
-    // Extract URL params and set appropriate settings
-    setSettingsFromURL();
-    populateMenuFromSettings();
 };
 
 window.onload = onLoad;
@@ -210,6 +207,14 @@ function closeOrExit() {
     exit();
 }
 
+function setSettingsFromJSON(msg) {
+    // Receive a menu message and set settings
+    var msg_json = JSON.parse(msg.data);
+    settings = msg_json["menu"];
+    defaultSettings = msg_json["defaults_menu"];
+    populateMenuFromSettings();
+}
+
 function setSettingsFromURL() {
     var { search } = window.location;
     // Actual settings
@@ -237,6 +242,7 @@ function setSettingsFromURL() {
         return accumulator;
     }, {});
     defaultSettings = defaultSettingsFromSearch;
+    populateMenuFromSettings()
 }
 
 function buildURLFromSettings() {

--- a/src/static/js/training_modpack.js
+++ b/src/static/js/training_modpack.js
@@ -184,7 +184,9 @@ const exit = () => {
 
     const url = buildURLFromSettings();
 
+
     if (isNx) {
+        window.nx.sendMessage(url);
         window.location.href = url;
     } else {
         console.log(url);

--- a/training_mod_consts/Cargo.toml
+++ b/training_mod_consts/Cargo.toml
@@ -14,6 +14,7 @@ ramhorns = "0.12.0"
 paste = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_repr = "0.1.8"
+serde_json = "1"
 bitflags_serde_shim = "0.2"
 skyline_smash = { git = "https://github.com/ultimate-research/skyline-smash.git", optional = true }
 

--- a/training_mod_consts/Cargo.toml
+++ b/training_mod_consts/Cargo.toml
@@ -13,6 +13,8 @@ num-traits = "0.2"
 ramhorns = "0.12.0"
 paste = "1.0"
 serde = { version = "1.0", features = ["derive"] }
+serde_repr = "0.1.8"
+bitflags_serde_shim = "0.2"
 skyline_smash = { git = "https://github.com/ultimate-research/skyline-smash.git", optional = true }
 
 [features]

--- a/training_mod_consts/src/lib.rs
+++ b/training_mod_consts/src/lib.rs
@@ -2,16 +2,20 @@
 extern crate bitflags;
 
 #[macro_use]
+extern crate bitflags_serde_shim;
+
+#[macro_use]
 extern crate num_derive;
 
 use core::f64::consts::PI;
-use std::collections::HashMap;
+use ramhorns::Content;
+use serde::{Deserialize, Serialize};
+use serde_repr::{Deserialize_repr, Serialize_repr};
 #[cfg(feature = "smash")]
 use smash::lib::lua_const::*;
+use std::collections::HashMap;
 use strum::IntoEnumIterator;
 use strum_macros::EnumIter;
-use serde::{Serialize, Deserialize};
-use ramhorns::Content;
 
 pub trait ToggleTrait {
     fn to_toggle_strs() -> Vec<&'static str>;
@@ -83,7 +87,9 @@ macro_rules! extra_bitflag_impls {
 
 pub fn get_random_int(_max: i32) -> i32 {
     #[cfg(feature = "smash")]
-    unsafe { smash::app::sv_math::rand(smash::hash40("fighter"), _max) }
+    unsafe {
+        smash::app::sv_math::rand(smash::hash40("fighter"), _max)
+    }
 
     #[cfg(not(feature = "smash"))]
     0
@@ -101,7 +107,6 @@ pub fn random_option<T>(arg: &[T]) -> &T {
 
 // DI / Left stick
 bitflags! {
-    #[derive(Serialize, Deserialize)]
     pub struct Direction : u32 {
         const OUT = 0x1;
         const UP_OUT = 0x2;
@@ -163,10 +168,10 @@ impl Direction {
 }
 
 extra_bitflag_impls! {Direction}
+impl_serde_for_bitflags!(Direction);
 
 // Ledge Option
 bitflags! {
-    #[derive(Serialize, Deserialize)]
     pub struct LedgeOption : u32
     {
         const NEUTRAL = 0x1;
@@ -179,7 +184,8 @@ bitflags! {
 
 impl LedgeOption {
     pub fn into_status(self) -> Option<i32> {
-        #[cfg(feature = "smash")] {
+        #[cfg(feature = "smash")]
+        {
             Some(match self {
                 LedgeOption::NEUTRAL => *FIGHTER_STATUS_KIND_CLIFF_CLIMB,
                 LedgeOption::ROLL => *FIGHTER_STATUS_KIND_CLIFF_ESCAPE,
@@ -207,10 +213,10 @@ impl LedgeOption {
 }
 
 extra_bitflag_impls! {LedgeOption}
+impl_serde_for_bitflags!(LedgeOption);
 
 // Tech options
 bitflags! {
-    #[derive(Serialize, Deserialize)]
     pub struct TechFlags : u32 {
         const NO_TECH = 0x1;
         const ROLL_F = 0x2;
@@ -232,10 +238,10 @@ impl TechFlags {
 }
 
 extra_bitflag_impls! {TechFlags}
+impl_serde_for_bitflags!(TechFlags);
 
 // Missed Tech Options
 bitflags! {
-    #[derive(Serialize, Deserialize)]
     pub struct MissTechFlags : u32 {
         const GETUP = 0x1;
         const ATTACK = 0x2;
@@ -257,10 +263,13 @@ impl MissTechFlags {
 }
 
 extra_bitflag_impls! {MissTechFlags}
+impl_serde_for_bitflags!(MissTechFlags);
 
 /// Shield States
 #[repr(i32)]
-#[derive(Debug, Clone, Copy, PartialEq, FromPrimitive, EnumIter, Serialize, Deserialize)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, FromPrimitive, EnumIter, Serialize_repr, Deserialize_repr,
+)]
 pub enum Shield {
     None = 0x0,
     Infinite = 0x1,
@@ -295,7 +304,9 @@ impl ToggleTrait for Shield {
 
 // Save State Mirroring
 #[repr(i32)]
-#[derive(Debug, Clone, Copy, PartialEq, FromPrimitive, EnumIter, Serialize, Deserialize)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, FromPrimitive, EnumIter, Serialize_repr, Deserialize_repr,
+)]
 pub enum SaveStateMirroring {
     None = 0x0,
     Alternate = 0x1,
@@ -318,7 +329,9 @@ impl SaveStateMirroring {
 
 impl ToggleTrait for SaveStateMirroring {
     fn to_toggle_strs() -> Vec<&'static str> {
-        SaveStateMirroring::iter().map(|i| i.as_str().unwrap_or("")).collect()
+        SaveStateMirroring::iter()
+            .map(|i| i.as_str().unwrap_or(""))
+            .collect()
     }
 
     fn to_toggle_vals() -> Vec<usize> {
@@ -328,7 +341,6 @@ impl ToggleTrait for SaveStateMirroring {
 
 // Defensive States
 bitflags! {
-    #[derive(Serialize, Deserialize)]
     pub struct Defensive : u32 {
         const SPOT_DODGE = 0x1;
         const ROLL_F = 0x2;
@@ -352,9 +364,10 @@ impl Defensive {
 }
 
 extra_bitflag_impls! {Defensive}
+impl_serde_for_bitflags!(Defensive);
 
 #[repr(i32)]
-#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Serialize_repr, Deserialize_repr)]
 pub enum OnOff {
     Off = 0,
     On = 1,
@@ -391,7 +404,6 @@ impl ToggleTrait for OnOff {
 }
 
 bitflags! {
-    #[derive(Serialize, Deserialize)]
     pub struct Action : u32 {
         const AIR_DODGE = 0x1;
         const JUMP = 0x2;
@@ -424,7 +436,8 @@ bitflags! {
 
 impl Action {
     pub fn into_attack_air_kind(self) -> Option<i32> {
-        #[cfg(feature = "smash")] {
+        #[cfg(feature = "smash")]
+        {
             Some(match self {
                 Action::NAIR => *FIGHTER_COMMAND_ATTACK_AIR_KIND_N,
                 Action::FAIR => *FIGHTER_COMMAND_ATTACK_AIR_KIND_F,
@@ -472,9 +485,9 @@ impl Action {
 }
 
 extra_bitflag_impls! {Action}
+impl_serde_for_bitflags!(Action);
 
 bitflags! {
-    #[derive(Serialize, Deserialize)]
     pub struct AttackAngle : u32 {
         const NEUTRAL = 0x1;
         const UP = 0x2;
@@ -494,9 +507,9 @@ impl AttackAngle {
 }
 
 extra_bitflag_impls! {AttackAngle}
+impl_serde_for_bitflags!(AttackAngle);
 
 bitflags! {
-    #[derive(Serialize, Deserialize)]
     pub struct Delay : u32 {
         const D0 = 0x1;
         const D1 = 0x2;
@@ -534,7 +547,6 @@ bitflags! {
 
 // Throw Option
 bitflags! {
-    #[derive(Serialize, Deserialize)]
     pub struct ThrowOption : u32
     {
         const NONE = 0x1;
@@ -547,7 +559,8 @@ bitflags! {
 
 impl ThrowOption {
     pub fn into_cmd(self) -> Option<i32> {
-        #[cfg(feature = "smash")] {
+        #[cfg(feature = "smash")]
+        {
             Some(match self {
                 ThrowOption::NONE => 0,
                 ThrowOption::FORWARD => *FIGHTER_PAD_CMD_CAT2_FLAG_THROW_F,
@@ -575,10 +588,10 @@ impl ThrowOption {
 }
 
 extra_bitflag_impls! {ThrowOption}
+impl_serde_for_bitflags!(ThrowOption);
 
 // Buff Option
 bitflags! {
-    #[derive(Serialize, Deserialize)]
     pub struct BuffOption : u32
     {
         const ACCELERATLE = 0x1;
@@ -595,7 +608,8 @@ bitflags! {
 
 impl BuffOption {
     pub fn into_int(self) -> Option<i32> {
-        #[cfg(feature = "smash")] {
+        #[cfg(feature = "smash")]
+        {
             Some(match self {
                 BuffOption::ACCELERATLE => *FIGHTER_BRAVE_SPECIAL_LW_COMMAND11_SPEED_UP,
                 BuffOption::OOMPH => *FIGHTER_BRAVE_SPECIAL_LW_COMMAND12_ATTACK_UP,
@@ -631,6 +645,7 @@ impl BuffOption {
 }
 
 extra_bitflag_impls! {BuffOption}
+impl_serde_for_bitflags!(BuffOption);
 
 impl Delay {
     pub fn as_str(self) -> Option<&'static str> {
@@ -676,9 +691,9 @@ impl Delay {
 }
 
 extra_bitflag_impls! {Delay}
+impl_serde_for_bitflags!(Delay);
 
 bitflags! {
-    #[derive(Serialize, Deserialize)]
     pub struct MedDelay : u32 {
         const D0 = 0x1;
         const D5 = 0x2;
@@ -758,9 +773,9 @@ impl MedDelay {
 }
 
 extra_bitflag_impls! {MedDelay}
+impl_serde_for_bitflags!(MedDelay);
 
 bitflags! {
-    #[derive(Serialize, Deserialize)]
     pub struct LongDelay : u32 {
         const D0 = 0x1;
         const D10 = 0x2;
@@ -840,9 +855,9 @@ impl LongDelay {
 }
 
 extra_bitflag_impls! {LongDelay}
+impl_serde_for_bitflags!(LongDelay);
 
 bitflags! {
-    #[derive(Serialize, Deserialize)]
     pub struct BoolFlag : u32 {
         const TRUE = 0x1;
         const FALSE = 0x2;
@@ -850,6 +865,7 @@ bitflags! {
 }
 
 extra_bitflag_impls! {BoolFlag}
+impl_serde_for_bitflags!(BoolFlag);
 
 impl BoolFlag {
     pub fn into_bool(self) -> bool {
@@ -865,7 +881,9 @@ impl BoolFlag {
 }
 
 #[repr(u32)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, FromPrimitive, EnumIter, Serialize, Deserialize)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, FromPrimitive, EnumIter, Serialize_repr, Deserialize_repr,
+)]
 pub enum InputFrequency {
     None = 0,
     Normal = 1,
@@ -899,7 +917,9 @@ impl InputFrequency {
 
 impl ToggleTrait for InputFrequency {
     fn to_toggle_strs() -> Vec<&'static str> {
-        InputFrequency::iter().map(|i| i.as_str().unwrap_or("")).collect()
+        InputFrequency::iter()
+            .map(|i| i.as_str().unwrap_or(""))
+            .collect()
     }
 
     fn to_toggle_vals() -> Vec<usize> {
@@ -922,7 +942,9 @@ impl ToUrlParam for i32 {
 
 /// Item Selections
 #[repr(i32)]
-#[derive(Debug, Clone, Copy, PartialEq, FromPrimitive, EnumIter, Serialize, Deserialize)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, FromPrimitive, EnumIter, Serialize_repr, Deserialize_repr,
+)]
 pub enum CharacterItem {
     None = 0,
     PlayerVariation1 = 0x1,
@@ -977,7 +999,9 @@ impl CharacterItem {
 
 impl ToggleTrait for CharacterItem {
     fn to_toggle_strs() -> Vec<&'static str> {
-        CharacterItem::iter().map(|i| i.as_str().unwrap_or("")).collect()
+        CharacterItem::iter()
+            .map(|i| i.as_str().unwrap_or(""))
+            .collect()
     }
 
     fn to_toggle_vals() -> Vec<usize> {
@@ -1075,11 +1099,14 @@ macro_rules! set_by_str {
     }
 }
 
-const fn num_bits<T>() -> usize { std::mem::size_of::<T>() * 8 }
+const fn num_bits<T>() -> usize {
+    std::mem::size_of::<T>() * 8
+}
 
 fn log_2(x: u32) -> u32 {
-    if x == 0 { 0 }
-    else {
+    if x == 0 {
+        0
+    } else {
         num_bits::<u32>() as u32 - x.leading_zeros() - 1
     }
 }
@@ -1131,6 +1158,14 @@ impl TrainingModpackMenu {
     }
 }
 
+#[repr(C)]
+#[derive(Debug, Serialize, Deserialize)]
+pub struct WebAppletResponse {
+    pub menu: TrainingModpackMenu,
+    pub defaults_menu: TrainingModpackMenu,
+     // pub last_focused_submenu: &str
+}
+
 // Fighter Ids
 #[repr(i32)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1146,11 +1181,11 @@ pub enum SubMenuType {
 }
 
 impl SubMenuType {
-    pub fn from_str(s : &str) -> SubMenuType {
+    pub fn from_str(s: &str) -> SubMenuType {
         match s {
             "toggle" => SubMenuType::TOGGLE,
             "slider" => SubMenuType::SLIDER,
-            _ => panic!("Unexpected SubMenuType!")
+            _ => panic!("Unexpected SubMenuType!"),
         }
     }
 }
@@ -1224,43 +1259,34 @@ pub struct SubMenu<'a> {
 }
 
 impl<'a> SubMenu<'a> {
-    pub fn add_toggle(
-        &mut self,
-        toggle_value: usize,
-        toggle_title: &'a str
-    ) {
-        self.toggles.push(
-            Toggle {
-                toggle_value: toggle_value,
-                toggle_title: toggle_title,
-                checked: false
-            }
-        );
+    pub fn add_toggle(&mut self, toggle_value: usize, toggle_title: &'a str) {
+        self.toggles.push(Toggle {
+            toggle_value: toggle_value,
+            toggle_title: toggle_title,
+            checked: false,
+        });
     }
-    pub fn new_with_toggles<T:ToggleTrait>(
+    pub fn new_with_toggles<T: ToggleTrait>(
         submenu_title: &'a str,
         submenu_id: &'a str,
         help_text: &'a str,
         is_single_option: bool,
     ) -> SubMenu<'a> {
-            let mut instance = SubMenu {
-                submenu_title: submenu_title,
-                submenu_id: submenu_id,
-                help_text: help_text,
-                is_single_option: is_single_option,
-                toggles: Vec::new(),
-                _type: "toggle"
-            };
-    
-            let values = T::to_toggle_vals();
-            let titles = T::to_toggle_strs();
-            for i in 0..values.len() {
-                instance.add_toggle(
-                    values[i],
-                    titles[i],
-                );
-            }
-            instance
+        let mut instance = SubMenu {
+            submenu_title: submenu_title,
+            submenu_id: submenu_id,
+            help_text: help_text,
+            is_single_option: is_single_option,
+            toggles: Vec::new(),
+            _type: "toggle",
+        };
+
+        let values = T::to_toggle_vals();
+        let titles = T::to_toggle_strs();
+        for i in 0..values.len() {
+            instance.add_toggle(values[i], titles[i]);
+        }
+        instance
     }
 }
 
@@ -1279,14 +1305,12 @@ impl<'a> Tab<'a> {
         help_text: &'a str,
         is_single_option: bool,
     ) {
-        self.tab_submenus.push(
-            SubMenu::new_with_toggles::<T>(
-                submenu_title,
-                submenu_id,
-                help_text,
-                is_single_option,
-            )
-        );
+        self.tab_submenus.push(SubMenu::new_with_toggles::<T>(
+            submenu_title,
+            submenu_id,
+            help_text,
+            is_single_option,
+        ));
     }
 }
 
@@ -1295,7 +1319,11 @@ pub struct UiMenu<'a> {
     pub tabs: Vec<Tab<'a>>,
 }
 
-pub fn get_menu_from_url(mut menu: TrainingModpackMenu, s: &str, defaults: bool) -> TrainingModpackMenu {
+pub fn get_menu_from_url(
+    mut menu: TrainingModpackMenu,
+    s: &str,
+    defaults: bool,
+) -> TrainingModpackMenu {
     let base_url_len = "http://localhost/?".len();
     let total_len = s.len();
 
@@ -1308,12 +1336,16 @@ pub fn get_menu_from_url(mut menu: TrainingModpackMenu, s: &str, defaults: bool)
     for toggle_values in ss.split('&') {
         let toggle_value_split = toggle_values.split('=').collect::<Vec<&str>>();
         let mut toggle = toggle_value_split[0];
-        if toggle.is_empty() | (
-            // Default menu settings begin with the prefix "__"
-            // So if skip toggles without the prefix if defaults is true
-            // And skip toggles with the prefix if defaults is false
-            defaults ^ toggle.starts_with("__")
-        ) { continue }
+        if toggle.is_empty()
+            | (
+                // Default menu settings begin with the prefix "__"
+                // So if skip toggles without the prefix if defaults is true
+                // And skip toggles with the prefix if defaults is false
+                defaults ^ toggle.starts_with("__")
+            )
+        {
+            continue;
+        }
         toggle = toggle.strip_prefix("__").unwrap_or(toggle);
 
         let bits: u32 = toggle_value_split[1].parse().unwrap_or(0);
@@ -1322,12 +1354,8 @@ pub fn get_menu_from_url(mut menu: TrainingModpackMenu, s: &str, defaults: bool)
     menu
 }
 
-
-
 pub unsafe fn get_menu() -> UiMenu<'static> {
-    let mut overall_menu = UiMenu {
-        tabs: Vec::new(),
-    };
+    let mut overall_menu = UiMenu { tabs: Vec::new() };
 
     let mut mash_tab = Tab {
         tab_id: "mash",
@@ -1420,7 +1448,6 @@ pub unsafe fn get_menu() -> UiMenu<'static> {
     );
     overall_menu.tabs.push(mash_tab);
 
-
     let mut defensive_tab = Tab {
         tab_id: "defensive",
         tab_title: "Defensive Settings",
@@ -1508,13 +1535,13 @@ pub unsafe fn get_menu() -> UiMenu<'static> {
         "Character Item",
         "character_item",
         "Character Item: CPU/Player item to hold when loading a save state",
-        true
+        true,
     );
     defensive_tab.add_submenu_with_toggles::<OnOff>(
         "Crouch",
         "crouch",
         "Crouch: Should the CPU crouch when on the ground",
-        true
+        true,
     );
     overall_menu.tabs.push(defensive_tab);
 
@@ -1569,41 +1596,43 @@ pub unsafe fn get_menu() -> UiMenu<'static> {
         "Stage Hazards",
         "stage_hazards",
         "Stage Hazards: Should stage hazards be present",
-        true
+        true,
     );
     misc_tab.add_submenu_with_toggles::<OnOff>(
         "Quick Menu",
         "quick_menu",
         "Quick Menu: Should use quick or web menu",
-        true
+        true,
     );
     overall_menu.tabs.push(misc_tab);
 
     let non_ui_menu = MENU;
     let url_params = non_ui_menu.to_url_params(false);
     let toggle_values_all = url_params.split("&");
-    let mut sub_menu_id_to_vals : HashMap<&str, u32> = HashMap::new();
+    let mut sub_menu_id_to_vals: HashMap<&str, u32> = HashMap::new();
     for toggle_values in toggle_values_all {
         let toggle_value_split = toggle_values.split('=').collect::<Vec<&str>>();
         let mut sub_menu_id = toggle_value_split[0];
-        if sub_menu_id.is_empty() { continue }
+        if sub_menu_id.is_empty() {
+            continue;
+        }
         sub_menu_id = sub_menu_id.strip_prefix("__").unwrap_or(sub_menu_id);
 
         let full_bits: u32 = toggle_value_split[1].parse().unwrap_or(0);
         sub_menu_id_to_vals.insert(sub_menu_id, full_bits);
     }
-    overall_menu.tabs.iter_mut()
-        .for_each(|tab| {
-            tab.tab_submenus.iter_mut().for_each(|sub_menu| {
-                let sub_menu_id = sub_menu.submenu_id;
-                sub_menu.toggles.iter_mut().for_each(|toggle| {
-                    if sub_menu_id_to_vals.contains_key(sub_menu_id) &&
-                        (sub_menu_id_to_vals[sub_menu_id] & (toggle.toggle_value as u32) != 0) {
-                        toggle.checked = true
-                    }
-                })
+    overall_menu.tabs.iter_mut().for_each(|tab| {
+        tab.tab_submenus.iter_mut().for_each(|sub_menu| {
+            let sub_menu_id = sub_menu.submenu_id;
+            sub_menu.toggles.iter_mut().for_each(|toggle| {
+                if sub_menu_id_to_vals.contains_key(sub_menu_id)
+                    && (sub_menu_id_to_vals[sub_menu_id] & (toggle.toggle_value as u32) != 0)
+                {
+                    toggle.checked = true
+                }
             })
-        });
+        })
+    });
 
     overall_menu
 }

--- a/training_mod_tui/src/lib.rs
+++ b/training_mod_tui/src/lib.rs
@@ -341,8 +341,6 @@ pub fn ui<B: Backend>(f: &mut Frame<B>, app: &mut App) -> String {
         f.render_widget(help_paragraph, vertical_chunks[2]);
     }
 
-
-    let mut url = "http://localhost/".to_owned();
     let mut settings = HashMap::new();
 
     // Collect settings for toggles
@@ -358,11 +356,7 @@ pub fn ui<B: Backend>(f: &mut Frame<B>, app: &mut App) -> String {
             }
         }
     }
-
-    url.push('?');
-    settings.iter()
-        .for_each(|(section, val)| url.push_str(format!("{}={}&", section, val).as_str()));
-    url
+    serde_json::to_string(&settings).unwrap()
 
     // TODO: Add saveDefaults
     // if (document.getElementById("saveDefaults").checked) {


### PR DESCRIPTION
This PR changes how the Web Menu receives and sends data to Rust. Previously, we were serializing the menu selections into URL query parameters, and using the initial/last URL to pass them between JS/Rust. This PR changes that serialization scheme to use JSON instead, and uses the WebSession message-passing functionality to pass them between JS/Rust.

The key advantage of this refactor is that it is more extensible and allows for more complex messages in the future, such as multiple menu presets or nested selections for followups.

The WebSession is preloaded when the user enters training mode, dramatically improving menu load times. This session is closed when the user exits training mode to avoid conflicting with other web plugins (e.g. Arcropolis). Re-starting the WebSession does cause some in-game lag when the menu is closed; I have some ideas on how to minimize that later on.

The training_modpack_menu.conf file has been updated to contain the JSON data instead of the URL. Configs in the URL format will be deleted and regenerated.

@jugeeya Note that training_mod_tui will need to be updated, since the Rust side now expects a response in JSON format instead of URL format. The quick menu will be broken until that is corrected. Could you please make that update, since it is closed-source?