### PR TITLE
Keep attributes for delayed input

### DIFF
--- a/src/training/input_delay.rs
+++ b/src/training/input_delay.rs
@@ -31,12 +31,16 @@ pub fn handle_get_npad_state(state: *mut NpadGcState, controller_id: *const u32)
 
                 if delayed_states.len() < MENU.input_delay.into_delay() as usize {
                     let update_count = (*state).updateCount;
+                    let attributes = (*state).Flags;
                     *state = NpadGcState::default();
                     (*state).updateCount = update_count;
+                    (*state).Flags = attributes;
                 } else if let Some(delayed_state) = delayed_states.back() {
                     let update_count = (*state).updateCount;
+                    let attributes = (*state).Flags;
                     *state = *delayed_state;
                     (*state).updateCount = update_count;
+                    (*state).Flags = attributes;
                 }
 
                 delayed_states.push_front(actual_state);


### PR DESCRIPTION
Fixes #389. We now grab the current controller attributes when setting input as none on input delay start up, preventing the controller state from being seen as disconnected.