### PR TITLE
No Star KOs

### DIFF
--- a/src/training/mod.rs
+++ b/src/training/mod.rs
@@ -460,13 +460,12 @@ pub unsafe fn handle_effect(
     )
 }
 
-static CAN_FUTTOBI_BACK_OFFSET: usize = 0x0260f950; // can_futtobi_back, I think this is a stage function and not a fighter function
+static CAN_FUTTOBI_BACK_OFFSET: usize = 0x0260f950; // can_futtobi_back, checks if stage allows for star KOs
 #[skyline::hook(offset = CAN_FUTTOBI_BACK_OFFSET)]
 pub unsafe fn handle_star_ko(
     my_long_ptr: &mut u64,
 ) -> bool {
     let ori = original!()(my_long_ptr);
-    println!("can_futtobi_back! val: {}",ori);
     if !is_training_mode() {
         return ori;
     } else {

--- a/src/training/mod.rs
+++ b/src/training/mod.rs
@@ -460,6 +460,20 @@ pub unsafe fn handle_effect(
     )
 }
 
+static CAN_FUTTOBI_BACK_OFFSET: usize = 0x0260f950; // can_futtobi_back, I think this is a stage function and not a fighter function
+#[skyline::hook(offset = CAN_FUTTOBI_BACK_OFFSET)]
+pub unsafe fn handle_star_ko(
+    my_long_ptr: &mut u64,
+) -> bool {
+    let ori = original!()(my_long_ptr);
+    println!("can_futtobi_back! val: {}",ori);
+    if !is_training_mode() {
+        return ori;
+    } else {
+        return false;
+    }
+}
+
 #[allow(improper_ctypes)]
 extern "C" {
     fn add_nn_hid_hook(callback: fn(*mut NpadGcState, *const u32));
@@ -540,6 +554,8 @@ pub fn training_mods() {
         handle_se,
         // Death GFX
         handle_effect,
+        // Star KO turn off
+        handle_star_ko,
     );
 
     combo::init();


### PR DESCRIPTION
Turns off Star KOs by hooking into the function that checks if a stage allows for Star KOs. We always return as if the current stage disallows Star KOs, so only regular blast zone kills off of the top occur.