### PR TITLE
Get the correct amount to reduce clatter time from start_clatter

### DIFF
--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -143,6 +143,8 @@ pub unsafe fn is_dead(module_accessor: &mut app::BattleObjectModuleAccessor) -> 
 }
 
 pub unsafe fn is_in_clatter(module_accessor: &mut app::BattleObjectModuleAccessor) -> bool {
+    // TODO: this function can give false positives if the clatter status ends for some reason
+    // other than a mash out (e.g. the fighter was thrown, or was hit hard enough)
     ControlModule::get_clatter_time(module_accessor, 0) > 0.0
 }
 

--- a/src/training/mod.rs
+++ b/src/training/mod.rs
@@ -553,6 +553,8 @@ pub fn training_mods() {
         handle_effect,
         // Star KO turn off
         handle_star_ko,
+        // Clatter
+        clatter::hook_start_clatter,
     );
 
     combo::init();


### PR DESCRIPTION
Closes #416 

When ControlModule::start_clatter() is called, grab the correct clatter step from the arguments. Then use that value when reducing the clatter time.