### PR TITLE
[Support MacOS build] Add vendored 'native-tls' as dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ serde_json = "1"
 toml = "0.5.9"
 training_mod_consts = { path = "training_mod_consts" }
 training_mod_tui = { path = "training_mod_tui" }
+native-tls = { version = "0.2.11", features = ["vendored"] }
 
 [patch.crates-io]
 native-tls = { git = "https://github.com/skyline-rs/rust-native-tls", branch="switch" }


### PR DESCRIPTION
Necessary for build to succeed on macOS