### PR TITLE
Fix rust-analyzer config

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
     "rust-analyzer.checkOnSave.overrideCommand": [
-        "xargo",
+        "cargo",
+        "+nightly",
         "clippy",
         "--workspace",
         "--message-format=json",
@@ -9,11 +10,4 @@
         "-A",
         "clippy::borrow_interior_mutable_const"
     ],
-    "rust-analyzer.updates.channel": "nightly",
-    "[javascript]": {
-        "editor.defaultFormatter": "esbenp.prettier-vscode"
-    },
-    "prettier.printWidth": 120,
-    "prettier.singleQuote": true,
-    "prettier.tabWidth": 4
 }


### PR DESCRIPTION
Applies the rust-analyzer config fix in  #439 but does not address the clippy warnings.