### PR TITLE
Refactor untechables

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
     "rust-analyzer.checkOnSave.overrideCommand": [
-        "xargo",
+        "cargo",
+        "+nightly",
         "clippy",
         "--workspace",
         "--message-format=json",
@@ -9,11 +10,4 @@
         "-A",
         "clippy::borrow_interior_mutable_const"
     ],
-    "rust-analyzer.updates.channel": "nightly",
-    "[javascript]": {
-        "editor.defaultFormatter": "esbenp.prettier-vscode"
-    },
-    "prettier.printWidth": 120,
-    "prettier.singleQuote": true,
-    "prettier.tabWidth": 4
 }

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -9,6 +9,7 @@ use crate::common::consts::*;
 use smash::app::{self, lua_bind::*};
 use smash::hash40;
 use smash::lib::lua_const::*;
+use smash::lua2cpp::L2CFighterCommon;
 
 pub use crate::common::consts::MENU;
 pub static mut DEFAULTS_MENU: TrainingModpackMenu = crate::common::consts::DEFAULTS_MENU;
@@ -241,4 +242,10 @@ pub unsafe fn get_fighter_distance() -> f32 {
         cpu_pos.y,
         cpu_pos.z,
     )
+}
+
+// From https://github.com/chrispo-git/ult-s/blob/cc1c3060ed83f6d33f39964e84f9c32c07a17bae/src/controls/util.rs#L106
+pub unsafe fn get_fighter_common_from_accessor(module_accessor: &mut app::BattleObjectModuleAccessor) -> &mut L2CFighterCommon {
+    let lua_module = *(module_accessor as *mut app::BattleObjectModuleAccessor as *mut u64).add(0x190 / 8);
+    &mut *(*((lua_module + 0x1D8) as *mut *mut L2CFighterCommon))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,6 @@ fn nro_main(nro: &NroInfo<'_>) {
             training::shield::handle_sub_guard_cont,
             training::directional_influence::handle_correct_damage_vector_common,
             training::tech::handle_change_status,
-            training::tech::mod_is_enable_passive,
         );
     }
 }


### PR DESCRIPTION
Instead of hooking `is_enable_passive` and setting a `static mut`, we can just call it directly instead. This is much cleaner and probably avoids issues w/ nana.