### PR TITLE
Keep Crafting Table on state load

### DIFF
--- a/src/training/save_states.rs
+++ b/src/training/save_states.rs
@@ -261,21 +261,20 @@ pub unsafe fn save_states(module_accessor: &mut app::BattleObjectModuleAccessor)
             PostureModule::set_pos(module_accessor, &pos);
 
             // All articles have ID <= 0x25
-            for article_idx in 0..=0x25 {
-                if ArticleModule::is_exist(module_accessor, article_idx) {
-                    let article: u64 = ArticleModule::get_article(module_accessor, article_idx);
-                    let article_object_id =
-                        Article::get_battle_object_id(article as *mut app::Article);
-                    // Don't remove crafting table
-                    if fighter_kind == *FIGHTER_KIND_PICKEL && article_idx == *FIGHTER_PICKEL_GENERATE_ARTICLE_TABLE {
-                        continue;
+            (0..=0x25)
+                // Don't remove crafting table
+                .filter(|article_idx| !(fighter_kind == *FIGHTER_KIND_PICKEL && *article_idx == *FIGHTER_PICKEL_GENERATE_ARTICLE_TABLE))
+                .for_each(|article_idx| {
+                    if ArticleModule::is_exist(module_accessor, article_idx) {
+                        let article: u64 = ArticleModule::get_article(module_accessor, article_idx);
+                        let article_object_id =
+                            Article::get_battle_object_id(article as *mut app::Article);
+                        ArticleModule::remove_exist_object_id(
+                            module_accessor,
+                            article_object_id as u32,
+                        );
                     }
-                    ArticleModule::remove_exist_object_id(
-                        module_accessor,
-                        article_object_id as u32,
-                    );
-                }
-            }
+                });
             let item_mgr = *(ITEM_MANAGER_ADDR as *mut *mut app::ItemManager);
             (0..ItemManager::get_num_of_active_item_all(item_mgr)).for_each(|item_idx| {
                 let item = ItemManager::get_active_item(item_mgr, item_idx);

--- a/src/training/save_states.rs
+++ b/src/training/save_states.rs
@@ -266,7 +266,7 @@ pub unsafe fn save_states(module_accessor: &mut app::BattleObjectModuleAccessor)
                     let article: u64 = ArticleModule::get_article(module_accessor, article_idx);
                     let article_object_id =
                         Article::get_battle_object_id(article as *mut app::Article);
-                    if fighter_kind != *FIGHTER_KIND_PICKEL || article_idx != 0x5 { // don't remove crafting table
+                    if fighter_kind != *FIGHTER_KIND_PICKEL || article_idx != *FIGHTER_PICKEL_GENERATE_ARTICLE_TABLE { // don't remove crafting table
                         ArticleModule::remove_exist_object_id(
                             module_accessor,
                             article_object_id as u32,

--- a/src/training/save_states.rs
+++ b/src/training/save_states.rs
@@ -261,19 +261,21 @@ pub unsafe fn save_states(module_accessor: &mut app::BattleObjectModuleAccessor)
             PostureModule::set_pos(module_accessor, &pos);
 
             // All articles have ID <= 0x25
-            (0..=0x25).for_each(|article_idx| {
+            for article_idx in 0..=0x25 {
                 if ArticleModule::is_exist(module_accessor, article_idx) {
                     let article: u64 = ArticleModule::get_article(module_accessor, article_idx);
                     let article_object_id =
                         Article::get_battle_object_id(article as *mut app::Article);
-                    if fighter_kind != *FIGHTER_KIND_PICKEL || article_idx != *FIGHTER_PICKEL_GENERATE_ARTICLE_TABLE { // don't remove crafting table
-                        ArticleModule::remove_exist_object_id(
-                            module_accessor,
-                            article_object_id as u32,
-                        );
-                    }  
+                    // Don't remove crafting table
+                    if fighter_kind == *FIGHTER_KIND_PICKEL && article_idx == *FIGHTER_PICKEL_GENERATE_ARTICLE_TABLE {
+                        continue;
+                    }
+                    ArticleModule::remove_exist_object_id(
+                        module_accessor,
+                        article_object_id as u32,
+                    );
                 }
-            });
+            }
             let item_mgr = *(ITEM_MANAGER_ADDR as *mut *mut app::ItemManager);
             (0..ItemManager::get_num_of_active_item_all(item_mgr)).for_each(|item_idx| {
                 let item = ItemManager::get_active_item(item_mgr, item_idx);

--- a/src/training/save_states.rs
+++ b/src/training/save_states.rs
@@ -266,10 +266,12 @@ pub unsafe fn save_states(module_accessor: &mut app::BattleObjectModuleAccessor)
                     let article: u64 = ArticleModule::get_article(module_accessor, article_idx);
                     let article_object_id =
                         Article::get_battle_object_id(article as *mut app::Article);
-                    ArticleModule::remove_exist_object_id(
-                        module_accessor,
-                        article_object_id as u32,
-                    );
+                    if fighter_kind != *FIGHTER_KIND_PICKEL || article_idx != 0x5 { // don't remove crafting table
+                        ArticleModule::remove_exist_object_id(
+                            module_accessor,
+                            article_object_id as u32,
+                        );
+                    }  
                 }
             });
             let item_mgr = *(ITEM_MANAGER_ADDR as *mut *mut app::ItemManager);


### PR DESCRIPTION
If the fighter is Steve and the article matches the index of Steve's crafting table, we don't remove it.