### PR TITLE
Fix issues w/ Quick menu

### DIFF
--- a/training_mod_consts/src/lib.rs
+++ b/training_mod_consts/src/lib.rs
@@ -1295,8 +1295,12 @@ impl<'a> SubMenu<'a> {
         let titles = T::to_toggle_strs();
         for i in 0..values.len() {
             let checked: bool  = (values[i] & initial_value) > 0
-             || (!values[i] == 0 && initial_value == &0);
+                || (!values[i] == 0 && initial_value == &0);
             instance.add_toggle(values[i], titles[i], checked);
+        }
+        // Select the first option if there's nothing selected atm but it's a single option submenu
+        if is_single_option && instance.toggles.iter().all(|t| !t.checked) {
+            instance.toggles[0].checked = true;
         }
         instance
     }


### PR DESCRIPTION
Fixed the following issues:
1. Quick menu `App` was not regenerated prior to opening the menu, so any changes made in the web menu wouldn't be reflected in the quick menu unless you also made them in the quick menu
2. Quick menu loop did not release its mutex guard
3. Single option submenus would not have their toggles `checked` if the selected option had a value of 0, which could cause those submenus to have no `checked` toggles at all
4. Quick menu closes immediately upon opening on console