### PR TITLE
Update UI for quickmenu slider values

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,7 +10,6 @@
 	"remoteEnv": {
 		"LOCAL_WORKSPACE_FOLDER": "${localWorkspaceFolder}"
 	},
-
 	"customizations": {
 		"vscode": {
 			"extensions": [

--- a/src/training/ui_hacks.rs
+++ b/src/training/ui_hacks.rs
@@ -535,7 +535,7 @@ pub unsafe fn handle_draw(layout: *mut Layout, draw_info: u64, cmd_buffer: u64) 
                     match index {
                         0 => text_pane.set_text_string("Min"),
                         1 => text_pane.set_text_string("Max"),
-                        _ => text_pane.set_text_string(""),
+                        _ => panic!("Unexpected slider label index {}!", index)
                     }
                 }
 

--- a/src/training/ui_hacks.rs
+++ b/src/training/ui_hacks.rs
@@ -525,7 +525,8 @@ pub unsafe fn handle_draw(layout: *mut Layout, draw_info: u64, cmd_buffer: u64) 
 
                     match index {
                         0 => text_pane.set_text_string(&format!("{abs_min}")),
-                        1 => {
+                        1 => text_pane.set_text_string(&format!("{abs_max}")),
+                        2 => {
                             text_pane.set_text_string(&format!("{selected_min}"));
                             match gauge_vals.state {
                                 GaugeState::MinHover => text_pane.set_color(200, 8, 8, 255),
@@ -533,7 +534,7 @@ pub unsafe fn handle_draw(layout: *mut Layout, draw_info: u64, cmd_buffer: u64) 
                                 _ => text_pane.set_color(0, 0, 0, 255),
                             }
                         },
-                        2 => {
+                        3 => {
                             text_pane.set_text_string(&format!("{selected_max}"));
                             match gauge_vals.state {
                                 GaugeState::MaxHover => text_pane.set_color(200, 8, 8, 255),
@@ -541,7 +542,6 @@ pub unsafe fn handle_draw(layout: *mut Layout, draw_info: u64, cmd_buffer: u64) 
                                 _ => text_pane.set_color(0, 0, 0, 255),
                             }
                         },
-                        3 => text_pane.set_text_string(&format!("{abs_max}")),
                         _ => text_pane.set_text_string("")
                     }
                 }

--- a/src/training/ui_hacks.rs
+++ b/src/training/ui_hacks.rs
@@ -106,6 +106,20 @@ const BG_LEFT_OFF_BLACK_COLOR: ResColor = ResColor {
     a: 0,
 };
 
+const BG_LEFT_SELECTED_BLACK_COLOR: ResColor = ResColor {
+    r: 130,
+    g: 31,
+    b: 31,
+    a: 0,
+};
+
+const BG_LEFT_SELECTED_WHITE_COLOR: ResColor = ResColor {
+    r: 145,
+    g: 33,
+    b: 33,
+    a: 255,
+};
+
 macro_rules! menu_text_name_fmt {
     ($x:ident, $y:ident) => {
         format!("trMod_menu_opt_{}_{}", $x, $y).as_str()
@@ -174,7 +188,9 @@ pub unsafe fn all_menu_panes_sorted(root_pane: &Pane) -> Vec<&mut Pane> {
         &mut (0..NUM_MENU_TEXT_SLIDERS)
             .map(|idx| {
                 root_pane
-                    .find_pane_by_name_recursive(format!("{}_lbl", menu_text_slider_fmt!(idx)).as_str())
+                    .find_pane_by_name_recursive(
+                        format!("{}_lbl", menu_text_slider_fmt!(idx)).as_str(),
+                    )
                     .unwrap()
             })
             .collect::<Vec<&mut Pane>>(),
@@ -356,13 +372,13 @@ pub unsafe fn handle_draw(layout: *mut Layout, draw_info: u64, cmd_buffer: u64) 
                 .map(|text| text.set_visible(false));
 
             root_pane
-            .find_pane_by_name_recursive(format!("trMod_menu_slider_{}_lbl", idx).as_str())
+                .find_pane_by_name_recursive(format!("trMod_menu_slider_{}_lbl", idx).as_str())
                 .map(|text| text.set_visible(false));
         });
-        
+
         root_pane
             .find_pane_by_name_recursive("slider_menu")
-                .map(|pane| pane.set_visible(false));
+            .map(|pane| pane.set_visible(false));
 
         let app_tabs = &app.tabs.items;
         let tab_selected = app.tabs.state.selected().unwrap();
@@ -506,20 +522,24 @@ pub unsafe fn handle_draw(layout: *mut Layout, draw_info: u64, cmd_buffer: u64) 
             }
 
             (0..NUM_MENU_TEXT_SLIDERS).for_each(|index| {
-                if let Some(text_pane) = root_pane.find_pane_by_name_recursive(format!("trMod_menu_slider_{}_lbl", index).as_str()) {
+                if let Some(text_pane) = root_pane.find_pane_by_name_recursive(
+                    format!("trMod_menu_slider_{}_lbl", index).as_str(),
+                ) {
                     let text_pane = text_pane.as_textbox();
                     text_pane.set_visible(true);
-                    
+
                     match index {
                         0 => text_pane.set_text_string("Min"),
                         1 => text_pane.set_text_string("Max"),
                         2 => text_pane.set_text_string("Current Min"),
                         3 => text_pane.set_text_string("Current Max"),
-                        _ => text_pane.set_text_string("")
+                        _ => text_pane.set_text_string(""),
                     }
                 }
 
-                if let Some(text_pane) = root_pane.find_pane_by_name_recursive(format!("trMod_menu_slider_{}", index).as_str()) {
+                if let Some(text_pane) = root_pane
+                    .find_pane_by_name_recursive(format!("trMod_menu_slider_{}", index).as_str())
+                {
                     let text_pane = text_pane.as_textbox();
                     text_pane.set_visible(true);
 
@@ -533,7 +553,7 @@ pub unsafe fn handle_draw(layout: *mut Layout, draw_info: u64, cmd_buffer: u64) 
                                 GaugeState::MinSelected => text_pane.set_color(8, 200, 8, 255),
                                 _ => text_pane.set_color(0, 0, 0, 255),
                             }
-                        },
+                        }
                         3 => {
                             text_pane.set_text_string(&format!("{selected_max}"));
                             match gauge_vals.state {
@@ -541,10 +561,77 @@ pub unsafe fn handle_draw(layout: *mut Layout, draw_info: u64, cmd_buffer: u64) 
                                 GaugeState::MaxSelected => text_pane.set_color(8, 200, 8, 255),
                                 _ => text_pane.set_color(0, 0, 0, 255),
                             }
-                        },
-                        _ => text_pane.set_text_string("")
+                        }
+                        _ => text_pane.set_text_string(""),
                     }
                 }
+
+                if let Some(bg_left) = root_pane
+                    .find_pane_by_name_recursive(format!("slider_btn_fg_{}", index).as_str())
+                {
+                    let bg_left_material = &mut *bg_left.as_picture().material;
+                    match gauge_vals.state {
+                        GaugeState::MinHover | GaugeState::MinSelected => {
+                            bg_left_material.set_white_res_color(BG_LEFT_ON_WHITE_COLOR);
+                            bg_left_material.set_black_res_color(BG_LEFT_ON_BLACK_COLOR);
+                        }
+                        _ => {
+                            bg_left_material.set_white_res_color(BG_LEFT_OFF_WHITE_COLOR);
+                            bg_left_material.set_black_res_color(BG_LEFT_OFF_BLACK_COLOR);
+                        }
+                    }
+                    bg_left_material.set_white_res_color(BG_LEFT_ON_WHITE_COLOR);
+                    bg_left_material.set_black_res_color(BG_LEFT_ON_BLACK_COLOR);
+                    bg_left.set_visible(true);
+                }
+                // if let Some(pic_pane) = root_pane.find_pane_by_name_recursive(format!("slider_btn_fg_{}", index).as_str()) {
+                //     let pic_pane = pic_pane.as_picture();
+                //     let pic_material = pic_pane.material.as_mut().unwrap();
+
+                //     pic_material.set_black_res_color(BG_LEFT_ON_BLACK_COLOR);
+                //     pic_material.set_white_res_color(BG_LEFT_SELECTED_WHITE_COLOR);
+                // match index {
+                //     2 => {
+                //         match gauge_vals.state {
+                //             GaugeState::MinHover => {
+                //                 pic_material.set_white_res_color(BG_LEFT_ON_WHITE_COLOR);
+                //                 pic_material.set_black_res_color(BG_LEFT_ON_BLACK_COLOR);
+                //             },
+                //             GaugeState::MinSelected => {
+                //                 println!("min, idx: 2 - sel");
+                //                 pic_material.set_white_res_color(BG_LEFT_SELECTED_WHITE_COLOR);
+                //                 pic_material.set_black_res_color(BG_LEFT_SELECTED_BLACK_COLOR);
+                //             },
+                //             _ => {
+                //                 pic_material.set_white_res_color(BG_LEFT_OFF_WHITE_COLOR);
+                //                 pic_material.set_black_res_color(BG_LEFT_OFF_BLACK_COLOR);
+                //             },
+                //         }
+                //     },
+                //     3 => {
+                //         match gauge_vals.state {
+                //             GaugeState::MaxHover => {
+                //                 pic_material.set_white_res_color(BG_LEFT_ON_WHITE_COLOR);
+                //                 pic_material.set_black_res_color(BG_LEFT_ON_BLACK_COLOR);
+                //             },
+                //             GaugeState::MaxSelected => {
+                //                 pic_material.set_white_res_color(BG_LEFT_SELECTED_WHITE_COLOR);
+                //                 pic_material.set_black_res_color(BG_LEFT_SELECTED_BLACK_COLOR);
+                //             },
+                //             _ => {
+                //                 pic_material.set_white_res_color(BG_LEFT_OFF_WHITE_COLOR);
+                //                 pic_material.set_black_res_color(BG_LEFT_OFF_BLACK_COLOR);
+                //             },
+                //         }
+                //     },
+                //     _ => {
+                //         pic_material.set_white_res_color(BG_LEFT_OFF_WHITE_COLOR);
+                //         pic_material.set_black_res_color(BG_LEFT_OFF_BLACK_COLOR);
+                //     }
+                // }
+
+                // pic_pane.set_visible(true);
+                // }
             });
         }
     }
@@ -644,21 +731,23 @@ pub unsafe fn layout_build_parts_impl(
                 }
             });
         }
-    
+
         (0..NUM_MENU_TEXT_SLIDERS).for_each(|index| {
             let x = index % 2;
             let y = index / 2;
 
             if (*block).name_matches("icn_bg_main") {
                 if MENU_PANE_PTR != 0 {
-                    let slider_root = (*(MENU_PANE_PTR as *mut Pane)).find_pane_by_name("slider_menu", true).unwrap();
+                    let slider_root = (*(MENU_PANE_PTR as *mut Pane))
+                        .find_pane_by_name("slider_menu", true)
+                        .unwrap();
 
                     let x_offset = x as f32 * 345.0;
                     let y_offset = y as f32 * 125.0;
 
                     let block = block as *mut ResPictureWithTex<2>;
                     let mut pic_menu_block = *block;
-                    
+
                     pic_menu_block.set_name(format!("slider_btn_fg_{}", index).as_str());
 
                     pic_menu_block.picture.scale_x /= 1.85;
@@ -672,20 +761,29 @@ pub unsafe fn layout_build_parts_impl(
 
                     let pic_menu_pane = build!(pic_menu_block, ResPictureWithTex<2>, kind, Picture);
                     pic_menu_pane.detach();
-                
+
                     slider_root.append_child(pic_menu_pane);
                 }
             }
             if (*block).name_matches("btn_bg") {
                 if MENU_PANE_PTR != 0 {
-                    let slider_root = (*(MENU_PANE_PTR as *mut Pane)).find_pane_by_name("slider_menu", true).unwrap();
+                    let slider_root = (*(MENU_PANE_PTR as *mut Pane))
+                        .find_pane_by_name("slider_menu", true)
+                        .unwrap();
 
-                    let size_x = slider_root.find_pane_by_name_recursive("slider_ui_container")
+                    let size_x = slider_root
+                        .find_pane_by_name_recursive("slider_ui_container")
                         .unwrap()
-                        .size_x * 0.9 / 2.0;
-                    let size_y = (slider_root.find_pane_by_name_recursive("slider_ui_container")
+                        .size_x
+                        * 0.9
+                        / 2.0;
+                    let size_y = (slider_root
+                        .find_pane_by_name_recursive("slider_ui_container")
                         .unwrap()
-                        .size_y * 0.50 - 20.0) / 2.0;
+                        .size_y
+                        * 0.50
+                        - 20.0)
+                        / 2.0;
 
                     println!("x: 450.0, y: {}", size_y);
 
@@ -698,10 +796,7 @@ pub unsafe fn layout_build_parts_impl(
                     bg_block.set_name(format!("slider_item_btn_{}", index).as_str());
                     bg_block.scale_x /= 2.0;
 
-                    bg_block.set_size(ResVec2::new(
-                        605.0,
-                        size_y
-                    ));
+                    bg_block.set_size(ResVec2::new(605.0, size_y));
 
                     bg_block.set_pos(ResVec3::new(
                         slider_root.pos_x - 700.0 + x_offset,
@@ -709,7 +804,8 @@ pub unsafe fn layout_build_parts_impl(
                         0.0,
                     ));
 
-                    let bg_pane = build!(bg_block, ResWindowWithTexCoordsAndFrames<1,4>, kind, Window);
+                    let bg_pane =
+                        build!(bg_block, ResWindowWithTexCoordsAndFrames<1,4>, kind, Window);
                     bg_pane.detach();
 
                     slider_root.append_child(bg_pane);
@@ -917,8 +1013,13 @@ pub unsafe fn layout_build_parts_impl(
         let mut slider_ui_root_block = ResPane::new(slider_root_name);
 
         slider_ui_root_block.set_pos(ResVec3::default());
-        
-        let slider_ui_root = build!(slider_ui_root_block, ResPane, slider_ui_root_pane_kind, Pane);
+
+        let slider_ui_root = build!(
+            slider_ui_root_block,
+            ResPane,
+            slider_ui_root_pane_kind,
+            Pane
+        );
 
         slider_ui_root.detach();
         menu_pane.append_child(slider_ui_root);
@@ -931,18 +1032,10 @@ pub unsafe fn layout_build_parts_impl(
         picture_block.set_size(ResVec2::new(675.0, 400.0));
         picture_block.set_pos(ResVec3::new(-530.0, 180.0, 0.0));
         picture_block.tex_coords = [
-            [
-                ResVec2::new(0.0, 0.0)
-            ],
-            [
-                ResVec2::new(1.0, 0.0)
-            ],
-            [
-                ResVec2::new(0.0, 2.0)
-            ],
-            [
-                ResVec2::new(1.0, 2.0)
-            ]
+            [ResVec2::new(0.0, 0.0)],
+            [ResVec2::new(1.0, 0.0)],
+            [ResVec2::new(0.0, 2.0)],
+            [ResVec2::new(1.0, 2.0)],
         ];
 
         let picture_pane = build!(picture_block, ResPictureWithTex<1>, kind, Picture);
@@ -964,7 +1057,7 @@ pub unsafe fn layout_build_parts_impl(
         let title_pane = build!(title_block, ResTextBox, kind, TextBox);
 
         title_pane.set_text_string(format!("Slider Title").as_str());
-        
+
         // Ensure Material Colors are not hardcoded so we can just use SetTextColor.
         title_pane.set_default_material_colors();
 
@@ -980,10 +1073,12 @@ pub unsafe fn layout_build_parts_impl(
 
         let label_x_offset = x as f32 * 345.0;
         let label_y_offset = y as f32 * 125.0;
-        
+
         if (*block).name_matches("set_txt_num_01") {
             let slider_root_pane = root_pane.find_pane_by_name(slider_root_name, true).unwrap();
-            let slider_container = root_pane.find_pane_by_name(slider_container_name, true).unwrap();
+            let slider_container = root_pane
+                .find_pane_by_name(slider_container_name, true)
+                .unwrap();
 
             let block = data as *mut ResTextBox;
 
@@ -1000,7 +1095,7 @@ pub unsafe fn layout_build_parts_impl(
             text_block.set_pos(ResVec3::new(
                 slider_root_pane.pos_x - 675.0 + value_x_offset,
                 slider_root_pane.pos_y + 200.0 - value_y_offset,
-                0.0
+                0.0,
             ));
 
             let text_pane = build!(text_block, ResTextBox, kind, TextBox);
@@ -1012,17 +1107,17 @@ pub unsafe fn layout_build_parts_impl(
             slider_root_pane.append_child(text_pane);
 
             let mut label_block = *block;
-            
+
             label_block.enable_shadow();
             label_block.text_alignment(TextAlignment::Center);
             label_block.set_name(format!("{}_lbl", menu_text_slider_fmt!(idx)).as_str());
             label_block.set_pos(ResVec3::new(
                 slider_root_pane.pos_x - 750.0 + label_x_offset,
                 slider_root_pane.pos_y + 205.0 - label_y_offset,
-                0.0
+                0.0,
             ));
             label_block.font_size = ResVec2::new(25.0, 50.0);
-            
+
             // Aligns text to the center horizontally
             label_block.text_position = 4;
 

--- a/src/training/ui_hacks.rs
+++ b/src/training/ui_hacks.rs
@@ -170,6 +170,16 @@ pub unsafe fn all_menu_panes_sorted(root_pane: &Pane) -> Vec<&mut Pane> {
             .collect::<Vec<&mut Pane>>(),
     );
 
+    panes.append(
+        &mut (0..NUM_MENU_TEXT_SLIDERS)
+            .map(|idx| {
+                root_pane
+                    .find_pane_by_name_recursive(format!("{}_lbl", menu_text_slider_fmt!(idx)).as_str())
+                    .unwrap()
+            })
+            .collect::<Vec<&mut Pane>>(),
+    );
+
     panes.sort_by(|a, _| {
         if a.get_name().contains("opt") || a.get_name().contains("check") {
             std::cmp::Ordering::Greater
@@ -346,7 +356,7 @@ pub unsafe fn handle_draw(layout: *mut Layout, draw_info: u64, cmd_buffer: u64) 
                 .map(|text| text.set_visible(false));
 
             root_pane
-            .find_pane_by_name_recursive(format!("trMod_menu_slider_{}_lbl", &idx).as_str())
+            .find_pane_by_name_recursive(format!("trMod_menu_slider_{}_lbl", idx).as_str())
                 .map(|text| text.set_visible(false));
         });
         
@@ -492,67 +502,50 @@ pub unsafe fn handle_draw(layout: *mut Layout, draw_info: u64, cmd_buffer: u64) 
 
             if let Some(text) = root_pane.find_pane_by_name_recursive("slider_title") {
                 let text = text.as_textbox();
-                text.set_visible(true);
                 text.set_text_string(&format!("{_title}"));
             }
 
-            if let Some(text) = root_pane.find_pane_by_name_recursive("trMod_menu_slider_0_lbl") {
-                let text = text.as_textbox();
-                text.set_visible(true);
-                text.set_text_string(&format!("Min"));
-            }
-
-            if let Some(text) = root_pane.find_pane_by_name_recursive("trMod_menu_slider_0") {
-                let text = text.as_textbox();
-                text.set_visible(true);
-                text.set_text_string(&format!("{abs_min}"));
-            }
-
-            if let Some(text) = root_pane.find_pane_by_name_recursive("trMod_menu_slider_1_lbl") {
-                let text = text.as_textbox();
-                text.set_visible(true);
-                text.set_text_string(&format!("Current Min"));
-            }
-
-            if let Some(text) = root_pane.find_pane_by_name_recursive("trMod_menu_slider_1") {
-                let text = text.as_textbox();
-                text.set_visible(true);
-                text.set_text_string(&format!("{selected_min}"));
-                match gauge_vals.state {
-                    GaugeState::MinHover => text.set_color(200, 8, 8, 255),
-                    GaugeState::MinSelected => text.set_color(8, 200, 8, 255),
-                    _ => text.set_color(0, 0, 0, 255),
+            (0..NUM_MENU_TEXT_SLIDERS).for_each(|index| {
+                if let Some(text_pane) = root_pane.find_pane_by_name_recursive(format!("trMod_menu_slider_{}_lbl", index).as_str()) {
+                    let text_pane = text_pane.as_textbox();
+                    text_pane.set_visible(true);
+                    
+                    match index {
+                        0 => text_pane.set_text_string("Min"),
+                        1 => text_pane.set_text_string("Max"),
+                        2 => text_pane.set_text_string("Current Min"),
+                        3 => text_pane.set_text_string("Current Max"),
+                        _ => text_pane.set_text_string("")
+                    }
                 }
-            }
 
-            if let Some(text) = root_pane.find_pane_by_name_recursive("trMod_menu_slider_2_lbl") {
-                let text = text.as_textbox();
-                text.set_visible(true);
-                text.set_text_string(&format!("Max"));
-            }
+                if let Some(text_pane) = root_pane.find_pane_by_name_recursive(format!("trMod_menu_slider_{}", index).as_str()) {
+                    let text_pane = text_pane.as_textbox();
+                    text_pane.set_visible(true);
 
-            if let Some(text) = root_pane.find_pane_by_name_recursive("trMod_menu_slider_2") {
-                let text = text.as_textbox();
-                text.set_visible(true);
-                text.set_text_string(&format!("{selected_max}"));
-                match gauge_vals.state {
-                    GaugeState::MaxHover => text.set_color(200, 8, 8, 255),
-                    GaugeState::MaxSelected => text.set_color(8, 200, 8, 255),
-                    _ => text.set_color(0, 0, 0, 255),
+                    match index {
+                        0 => text_pane.set_text_string(&format!("{abs_min}")),
+                        1 => {
+                            text_pane.set_text_string(&format!("{selected_min}"));
+                            match gauge_vals.state {
+                                GaugeState::MinHover => text_pane.set_color(200, 8, 8, 255),
+                                GaugeState::MinSelected => text_pane.set_color(8, 200, 8, 255),
+                                _ => text_pane.set_color(0, 0, 0, 255),
+                            }
+                        },
+                        2 => {
+                            text_pane.set_text_string(&format!("{selected_max}"));
+                            match gauge_vals.state {
+                                GaugeState::MaxHover => text_pane.set_color(200, 8, 8, 255),
+                                GaugeState::MaxSelected => text_pane.set_color(8, 200, 8, 255),
+                                _ => text_pane.set_color(0, 0, 0, 255),
+                            }
+                        },
+                        3 => text_pane.set_text_string(&format!("{abs_max}")),
+                        _ => text_pane.set_text_string("")
+                    }
                 }
-            }
-
-            if let Some(text) = root_pane.find_pane_by_name_recursive("trMod_menu_slider_3_lbl") {
-                let text = text.as_textbox();
-                text.set_visible(true);
-                text.set_text_string(&format!("Current Max"));
-            }
-
-            if let Some(text) = root_pane.find_pane_by_name_recursive("trMod_menu_slider_3") {
-                let text = text.as_textbox();
-                text.set_visible(true);
-                text.set_text_string(&format!("{abs_max}"));
-            }
+            });
         }
     }
 
@@ -651,6 +644,78 @@ pub unsafe fn layout_build_parts_impl(
                 }
             });
         }
+    
+        (0..NUM_MENU_TEXT_SLIDERS).for_each(|index| {
+            let x = index % 2;
+            let y = index / 2;
+
+            if (*block).name_matches("icn_bg_main") {
+                if MENU_PANE_PTR != 0 {
+                    let slider_root = (*(MENU_PANE_PTR as *mut Pane)).find_pane_by_name("slider_menu", true).unwrap();
+
+                    let x_offset = x as f32 * 345.0;
+                    let y_offset = y as f32 * 125.0;
+
+                    let block = block as *mut ResPictureWithTex<2>;
+                    let mut pic_menu_block = *block;
+                    
+                    pic_menu_block.set_name(format!("slider_btn_fg_{}", index).as_str());
+
+                    pic_menu_block.picture.scale_x /= 1.85;
+                    pic_menu_block.picture.scale_y /= 1.25;
+
+                    pic_menu_block.set_pos(ResVec3::new(
+                        slider_root.pos_x - 842.5 + x_offset,
+                        slider_root.pos_y + 200.0 - y_offset,
+                        0.0,
+                    ));
+
+                    let pic_menu_pane = build!(pic_menu_block, ResPictureWithTex<2>, kind, Picture);
+                    pic_menu_pane.detach();
+                
+                    slider_root.append_child(pic_menu_pane);
+                }
+            }
+            if (*block).name_matches("btn_bg") {
+                if MENU_PANE_PTR != 0 {
+                    let slider_root = (*(MENU_PANE_PTR as *mut Pane)).find_pane_by_name("slider_menu", true).unwrap();
+
+                    let size_x = slider_root.find_pane_by_name_recursive("slider_ui_container")
+                        .unwrap()
+                        .size_x * 0.9 / 2.0;
+                    let size_y = (slider_root.find_pane_by_name_recursive("slider_ui_container")
+                        .unwrap()
+                        .size_y * 0.50 - 20.0) / 2.0;
+
+                    println!("x: 450.0, y: {}", size_y);
+
+                    let x_offset = x as f32 * 345.0;
+                    let y_offset = y as f32 * 125.0;
+
+                    let block = block as *mut ResWindowWithTexCoordsAndFrames<1, 4>;
+                    let mut bg_block = *block;
+
+                    bg_block.set_name(format!("slider_item_btn_{}", index).as_str());
+                    bg_block.scale_x /= 2.0;
+
+                    bg_block.set_size(ResVec2::new(
+                        605.0,
+                        size_y
+                    ));
+
+                    bg_block.set_pos(ResVec3::new(
+                        slider_root.pos_x - 700.0 + x_offset,
+                        slider_root.pos_y + 200.0 - y_offset,
+                        0.0,
+                    ));
+
+                    let bg_pane = build!(bg_block, ResWindowWithTexCoordsAndFrames<1,4>, kind, Window);
+                    bg_pane.detach();
+
+                    slider_root.append_child(bg_pane);
+                }
+            }
+        });
     }
 
     if layout_name != "info_training" {
@@ -843,12 +908,13 @@ pub unsafe fn layout_build_parts_impl(
     // Slider visualization
 
     // UI Backing
-    let slider_container_name = "slider_menu";
+    let slider_root_name = "slider_menu";
+    let slider_container_name = "slider_ui_container";
 
     if (*block).name_matches("pic_numbase_01") {
         let menu_pane = root_pane.find_pane_by_name("trMod_menu", true).unwrap();
         let slider_ui_root_pane_kind = u32::from_le_bytes([b'p', b'a', b'n', b'1']);
-        let mut slider_ui_root_block = ResPane::new(slider_container_name);
+        let mut slider_ui_root_block = ResPane::new(slider_root_name);
 
         slider_ui_root_block.set_pos(ResVec3::default());
         
@@ -861,8 +927,8 @@ pub unsafe fn layout_build_parts_impl(
 
         let mut picture_block = *block;
 
-        picture_block.set_name("slider_ui_container");
-        picture_block.set_size(ResVec2::new(554.0, 306.0));
+        picture_block.set_name(slider_container_name);
+        picture_block.set_size(ResVec2::new(675.0, 400.0));
         picture_block.set_pos(ResVec3::new(-530.0, 180.0, 0.0));
         picture_block.tex_coords = [
             [
@@ -885,14 +951,15 @@ pub unsafe fn layout_build_parts_impl(
     }
 
     if (*block).name_matches("txt_cap_01") {
-        let container_pane = root_pane.find_pane_by_name(slider_container_name, true).unwrap();
+        let container_pane = root_pane.find_pane_by_name(slider_root_name, true).unwrap();
 
         let block = data as *mut ResTextBox;
         let mut title_block = *block;
 
         title_block.set_name("slider_title");
-        title_block.set_pos(ResVec3::new(-530.0, 298.0, 0.0));
-        title_block.set_size(ResVec2::new(550.0, 302.0));
+        title_block.set_pos(ResVec3::new(-530.0, 335.0, 0.0));
+        title_block.set_size(ResVec2::new(550.0, 100.0));
+        title_block.font_size = ResVec2::new(50.0, 100.0);
 
         let title_pane = build!(title_block, ResTextBox, kind, TextBox);
 
@@ -908,53 +975,63 @@ pub unsafe fn layout_build_parts_impl(
     }
 
     (0..NUM_MENU_TEXT_SLIDERS).for_each(|idx| {
+        let x = idx % 2;
+        let y = idx / 2;
+
+        let label_x_offset = x as f32 * 400.0;
+        let label_y_offset = y as f32 * 125.0;
+        
         if (*block).name_matches("set_txt_num_01") {
-            let container_pane = root_pane.find_pane_by_name(slider_container_name, true).unwrap();
+            let slider_root_pane = root_pane.find_pane_by_name(slider_root_name, true).unwrap();
+            let slider_container = root_pane.find_pane_by_name(slider_container_name, true).unwrap();
 
             let block = data as *mut ResTextBox;
+
             let mut text_block = *block;
-            let mut label_block = *block;
 
             text_block.enable_shadow();
             text_block.text_alignment(TextAlignment::Center);
 
-            label_block.enable_shadow();
-            label_block.text_alignment(TextAlignment::Center);
-
             text_block.set_name(menu_text_slider_fmt!(idx));
 
-            label_block.set_name(format!("{}_lbl", menu_text_slider_fmt!(idx)).as_str());
+            let value_x_offset = x as f32 * 345.0;
+            let value_y_offset = y as f32 * 125.0;
 
-            let x_offset = idx as f32 * 250.0;
             text_block.set_pos(ResVec3::new(
-                container_pane.pos_x - 661.5 + x_offset,
-                container_pane.pos_y - 191.0,
-                0.0,
-            ));
-
-            label_block.set_pos(ResVec3::new(
-                container_pane.pos_x - 661.5 + x_offset,
-                container_pane.pos_y - 125.0,
-                0.0,
+                slider_root_pane.pos_x - 675.0 + value_x_offset,
+                slider_root_pane.pos_y + 200.0 - value_y_offset,
+                0.0
             ));
 
             let text_pane = build!(text_block, ResTextBox, kind, TextBox);
-            text_pane.set_text_string(format!("Slider {idx}!").as_str());
+            text_pane.set_text_string(format!("Slider opt {idx}!").as_str());
             // Ensure Material Colors are not hardcoded so we can just use SetTextColor.
             text_pane.set_default_material_colors();
             text_pane.set_color(0, 0, 0, 255);
             text_pane.detach();
-            container_pane.append_child(text_pane);
+            slider_root_pane.append_child(text_pane);
+
+            let mut label_block = *block;
+            
+            label_block.enable_shadow();
+            label_block.text_alignment(TextAlignment::Center);
+            label_block.set_name(format!("{}_lbl", menu_text_slider_fmt!(idx)).as_str());
+            label_block.set_pos(ResVec3::new(
+                slider_root_pane.pos_x - 835.0 + label_x_offset,
+                slider_root_pane.pos_y + 200.0 - label_y_offset,
+                0.0
+            ));
+            label_block.font_size = ResVec2::new(25.0, 50.0);
 
             let label_pane = build!(label_block, ResTextBox, kind, TextBox);
-            label_pane.set_text_string(format!("Slider {idx}!").as_str());
+
+            label_pane.set_text_string(format!("Slider opt {idx}!").as_str());
             // Ensure Material Colors are not hardcoded so we can just use SetTextColor.
             label_pane.set_default_material_colors();
-            label_pane.set_color(0, 0, 0, 255);
+            label_pane.set_color(250, 250, 250, 255);
             label_pane.detach();
-            container_pane.append_child(label_pane);
 
-            // println!("{:#?}", container_pane.);
+            slider_root_pane.append_child(label_pane);
         }
     });
 

--- a/src/training/ui_hacks.rs
+++ b/src/training/ui_hacks.rs
@@ -978,7 +978,7 @@ pub unsafe fn layout_build_parts_impl(
         let x = idx % 2;
         let y = idx / 2;
 
-        let label_x_offset = x as f32 * 400.0;
+        let label_x_offset = x as f32 * 345.0;
         let label_y_offset = y as f32 * 125.0;
         
         if (*block).name_matches("set_txt_num_01") {
@@ -1017,11 +1017,14 @@ pub unsafe fn layout_build_parts_impl(
             label_block.text_alignment(TextAlignment::Center);
             label_block.set_name(format!("{}_lbl", menu_text_slider_fmt!(idx)).as_str());
             label_block.set_pos(ResVec3::new(
-                slider_root_pane.pos_x - 835.0 + label_x_offset,
+                slider_root_pane.pos_x - 750.0 + label_x_offset,
                 slider_root_pane.pos_y + 200.0 - label_y_offset,
                 0.0
             ));
             label_block.font_size = ResVec2::new(25.0, 50.0);
+            
+            // Aligns text to the center horizontally
+            label_block.text_position = 4;
 
             let label_pane = build!(label_block, ResTextBox, kind, TextBox);
 

--- a/src/training/ui_hacks.rs
+++ b/src/training/ui_hacks.rs
@@ -1018,7 +1018,7 @@ pub unsafe fn layout_build_parts_impl(
             label_block.set_name(format!("{}_lbl", menu_text_slider_fmt!(idx)).as_str());
             label_block.set_pos(ResVec3::new(
                 slider_root_pane.pos_x - 750.0 + label_x_offset,
-                slider_root_pane.pos_y + 200.0 - label_y_offset,
+                slider_root_pane.pos_y + 205.0 - label_y_offset,
                 0.0
             ));
             label_block.font_size = ResVec2::new(25.0, 50.0);

--- a/src/training/ui_hacks.rs
+++ b/src/training/ui_hacks.rs
@@ -583,7 +583,7 @@ pub unsafe fn handle_draw(layout: *mut Layout, draw_info: u64, cmd_buffer: u64) 
                     match index {
                         0 => text_pane.set_text_string(&format!("{selected_min}")),
                         1 => text_pane.set_text_string(&format!("{selected_max}")),
-                        _ => text_pane.set_text_string(""),
+                        _ => panic!("Unexpected slider label index {}!", index),
                     }
                 }
 
@@ -621,10 +621,7 @@ pub unsafe fn handle_draw(layout: *mut Layout, draw_info: u64, cmd_buffer: u64) 
                                 bg_left_material.set_black_res_color(BG_LEFT_OFF_BLACK_COLOR);
                             }
                         },
-                        _ => {
-                            bg_left_material.set_white_res_color(BG_LEFT_OFF_WHITE_COLOR);
-                            bg_left_material.set_black_res_color(BG_LEFT_OFF_BLACK_COLOR);
-                        }
+                        _ => panic!("Unexpected slider label index {}!", index),
                     }
                     bg_left.set_visible(true);
                 }

--- a/src/training/ui_hacks.rs
+++ b/src/training/ui_hacks.rs
@@ -107,14 +107,21 @@ const BG_LEFT_OFF_BLACK_COLOR: ResColor = ResColor {
 };
 
 const BG_LEFT_SELECTED_BLACK_COLOR: ResColor = ResColor {
-    r: 80,
-    g: 0,
-    b: 0,
+    r: 240,
+    g: 154,
+    b: 7,
     a: 0,
 };
 
 const BG_LEFT_SELECTED_WHITE_COLOR: ResColor = ResColor {
-    r: 118,
+    r: 255,
+    g: 166,
+    b: 7,
+    a: 255,
+};
+
+const BLACK: ResColor = ResColor {
+    r: 0,
     g: 0,
     b: 0,
     a: 255,
@@ -194,9 +201,7 @@ pub unsafe fn all_menu_panes_sorted(root_pane: &Pane) -> Vec<&mut Pane> {
         &mut (0..NUM_MENU_TEXT_SLIDERS)
             .map(|idx| {
                 root_pane
-                    .find_pane_by_name_recursive(
-                        menu_slider_label_fmt!(idx)
-                    )
+                    .find_pane_by_name_recursive(menu_slider_label_fmt!(idx))
                     .unwrap()
             })
             .collect::<Vec<&mut Pane>>(),
@@ -533,9 +538,39 @@ pub unsafe fn handle_draw(layout: *mut Layout, draw_info: u64, cmd_buffer: u64) 
                     text_pane.set_visible(true);
 
                     match index {
-                        0 => text_pane.set_text_string("Min"),
-                        1 => text_pane.set_text_string("Max"),
-                        _ => panic!("Unexpected slider label index {}!", index)
+                        0 => {
+                            text_pane.set_text_string("Min");
+
+                            match gauge_vals.state {
+                                GaugeState::MinHover | GaugeState::MinSelected => {
+                                    text_pane.m_bits |= 1 << TextBoxFlag::ShadowEnabled as u8;
+                                    text_pane.m_bits = text_pane.m_bits & !(1 << TextBoxFlag::InvisibleBorderEnabled as u8);
+                                    text_pane.set_color(255, 255, 255, 255);
+                                }
+                                _ => {
+                                    text_pane.m_bits = text_pane.m_bits & !(1 << TextBoxFlag::ShadowEnabled as u8);
+                                    text_pane.m_bits |= 1 << TextBoxFlag::InvisibleBorderEnabled as u8;
+                                    text_pane.set_color(85, 89, 92, 255);
+                                }
+                            }
+                        }
+                        1 => {
+                            text_pane.set_text_string("Max");
+
+                            match gauge_vals.state {
+                                GaugeState::MaxHover | GaugeState::MaxSelected => {
+                                    text_pane.m_bits |= 1 << TextBoxFlag::ShadowEnabled as u8;
+                                    text_pane.m_bits = text_pane.m_bits & !(1 << TextBoxFlag::InvisibleBorderEnabled as u8);
+                                    text_pane.set_color(255, 255, 255, 255);
+                                }
+                                _ => {
+                                    text_pane.m_bits |= 1 << TextBoxFlag::InvisibleBorderEnabled as u8;
+                                    text_pane.m_bits = text_pane.m_bits & !(1 << TextBoxFlag::ShadowEnabled as u8);
+                                    text_pane.set_color(85, 89, 92, 255);
+                                }
+                            }
+                        }
+                        _ => panic!("Unexpected slider label index {}!", index),
                     }
                 }
 
@@ -558,36 +593,32 @@ pub unsafe fn handle_draw(layout: *mut Layout, draw_info: u64, cmd_buffer: u64) 
                     let bg_left_material = &mut *bg_left.as_picture().material;
 
                     match index {
-                        0 => {
-                            match gauge_vals.state {
-                                GaugeState::MinHover => {
-                                    bg_left_material.set_white_res_color(BG_LEFT_ON_WHITE_COLOR);
-                                    bg_left_material.set_black_res_color(BG_LEFT_ON_BLACK_COLOR);
-                                },
-                                GaugeState::MinSelected => {
-                                    bg_left_material.set_white_res_color(BG_LEFT_SELECTED_WHITE_COLOR);
-                                    bg_left_material.set_black_res_color(BG_LEFT_SELECTED_BLACK_COLOR);
-                                },
-                                _ => {
-                                    bg_left_material.set_white_res_color(BG_LEFT_OFF_WHITE_COLOR);
-                                    bg_left_material.set_black_res_color(BG_LEFT_OFF_BLACK_COLOR);
-                                }
+                        0 => match gauge_vals.state {
+                            GaugeState::MinHover => {
+                                bg_left_material.set_white_res_color(BG_LEFT_ON_WHITE_COLOR);
+                                bg_left_material.set_black_res_color(BG_LEFT_ON_BLACK_COLOR);
+                            }
+                            GaugeState::MinSelected => {
+                                bg_left_material.set_white_res_color(BG_LEFT_SELECTED_WHITE_COLOR);
+                                bg_left_material.set_black_res_color(BG_LEFT_SELECTED_BLACK_COLOR);
+                            }
+                            _ => {
+                                bg_left_material.set_white_res_color(BG_LEFT_OFF_WHITE_COLOR);
+                                bg_left_material.set_black_res_color(BG_LEFT_OFF_BLACK_COLOR);
                             }
                         },
-                        1 => {
-                            match gauge_vals.state {
-                                GaugeState::MaxHover => {
-                                    bg_left_material.set_white_res_color(BG_LEFT_ON_WHITE_COLOR);
-                                    bg_left_material.set_black_res_color(BG_LEFT_ON_BLACK_COLOR);
-                                },
-                                GaugeState::MaxSelected => {
-                                    bg_left_material.set_white_res_color(BG_LEFT_SELECTED_WHITE_COLOR);
-                                    bg_left_material.set_black_res_color(BG_LEFT_SELECTED_BLACK_COLOR);
-                                },
-                                _ => {
-                                    bg_left_material.set_white_res_color(BG_LEFT_OFF_WHITE_COLOR);
-                                    bg_left_material.set_black_res_color(BG_LEFT_OFF_BLACK_COLOR);
-                                }
+                        1 => match gauge_vals.state {
+                            GaugeState::MaxHover => {
+                                bg_left_material.set_white_res_color(BG_LEFT_ON_WHITE_COLOR);
+                                bg_left_material.set_black_res_color(BG_LEFT_ON_BLACK_COLOR);
+                            }
+                            GaugeState::MaxSelected => {
+                                bg_left_material.set_white_res_color(BG_LEFT_SELECTED_WHITE_COLOR);
+                                bg_left_material.set_black_res_color(BG_LEFT_SELECTED_BLACK_COLOR);
+                            }
+                            _ => {
+                                bg_left_material.set_white_res_color(BG_LEFT_OFF_WHITE_COLOR);
+                                bg_left_material.set_black_res_color(BG_LEFT_OFF_BLACK_COLOR);
                             }
                         },
                         _ => {
@@ -702,12 +733,15 @@ pub unsafe fn layout_build_parts_impl(
         if !HAS_CREATED_SLIDER_BG && (*block).name_matches("icn_bg_main") {
             (0..NUM_MENU_TEXT_SLIDERS).for_each(|index| {
                 let x = index % 2;
-            
+
                 if MENU_PANE_PTR != 0 {
-                    let slider_root = (*(MENU_PANE_PTR as *mut Pane)).find_pane_by_name("slider_menu", true).unwrap();
-                    let slider_bg = (*(MENU_PANE_PTR as *mut Pane)).find_pane_by_name("slider_ui_container", true).unwrap();
+                    let slider_root = (*(MENU_PANE_PTR as *mut Pane))
+                        .find_pane_by_name("slider_menu", true)
+                        .unwrap();
+                    let slider_bg = (*(MENU_PANE_PTR as *mut Pane))
+                        .find_pane_by_name("slider_ui_container", true)
+                        .unwrap();
                     let x_offset = x as f32 * 345.0;
-                    
 
                     let block = block as *mut ResPictureWithTex<2>;
                     let mut pic_menu_block = *block;
@@ -731,14 +765,18 @@ pub unsafe fn layout_build_parts_impl(
                 }
             });
         }
-        
+
         if !HAS_CREATED_SLIDER_BG_BACK && (*block).name_matches("btn_bg") {
             (0..NUM_MENU_TEXT_SLIDERS).for_each(|index| {
                 let x = index % 2;
 
                 if MENU_PANE_PTR != 0 {
-                    let slider_root = (*(MENU_PANE_PTR as *mut Pane)).find_pane_by_name("slider_menu", true).unwrap();
-                    let slider_bg = (*(MENU_PANE_PTR as *mut Pane)).find_pane_by_name("slider_ui_container", true).unwrap();
+                    let slider_root = (*(MENU_PANE_PTR as *mut Pane))
+                        .find_pane_by_name("slider_menu", true)
+                        .unwrap();
+                    let slider_bg = (*(MENU_PANE_PTR as *mut Pane))
+                        .find_pane_by_name("slider_ui_container", true)
+                        .unwrap();
 
                     let size_y = 90.0;
 
@@ -750,10 +788,7 @@ pub unsafe fn layout_build_parts_impl(
                     bg_block.set_name(format!("slider_item_btn_{}", index).as_str());
                     bg_block.scale_x /= 2.0;
 
-                    bg_block.set_size(ResVec2::new(
-                        605.0,
-                        size_y
-                    ));
+                    bg_block.set_size(ResVec2::new(605.0, size_y));
 
                     bg_block.set_pos(ResVec3::new(
                         slider_root.pos_x - 700.0 + x_offset,
@@ -1064,7 +1099,6 @@ pub unsafe fn layout_build_parts_impl(
 
             let mut label_block = *block;
 
-            label_block.enable_shadow();
             label_block.text_alignment(TextAlignment::Center);
             label_block.set_name(menu_slider_label_fmt!(idx));
             label_block.set_pos(ResVec3::new(
@@ -1077,12 +1111,18 @@ pub unsafe fn layout_build_parts_impl(
             // Aligns text to the center horizontally
             label_block.text_position = 4;
 
+            label_block.shadow_offset = ResVec2::new(4.0, -3.0);
+            label_block.shadow_cols = [BLACK, BLACK];
+            label_block.shadow_scale = ResVec2::new(1.0, 1.0);
+
             let label_pane = build!(label_block, ResTextBox, kind, TextBox);
 
             label_pane.set_text_string(format!("Slider opt {idx}!").as_str());
             // Ensure Material Colors are not hardcoded so we can just use SetTextColor.
             label_pane.set_default_material_colors();
-            label_pane.set_color(250, 250, 250, 255);
+            label_pane.set_color(85, 89, 92, 255);
+            // Turns on text outline
+            label_pane.m_bits = label_pane.m_bits & !(1 << TextBoxFlag::InvisibleBorderEnabled as u8);
             label_pane.detach();
 
             slider_root_pane.append_child(label_pane);

--- a/src/training/ui_hacks.rs
+++ b/src/training/ui_hacks.rs
@@ -150,6 +150,12 @@ macro_rules! menu_text_slider_fmt {
     };
 }
 
+macro_rules! menu_slider_label_fmt {
+    ($x:ident) => {
+        format!("trMod_menu_slider_{}_lbl", $x).as_str()
+    };
+}
+
 // Sort all panes in under menu pane such that text and check options
 // are last
 pub unsafe fn all_menu_panes_sorted(root_pane: &Pane) -> Vec<&mut Pane> {
@@ -189,7 +195,7 @@ pub unsafe fn all_menu_panes_sorted(root_pane: &Pane) -> Vec<&mut Pane> {
             .map(|idx| {
                 root_pane
                     .find_pane_by_name_recursive(
-                        format!("{}_lbl", menu_text_slider_fmt!(idx)).as_str(),
+                        menu_slider_label_fmt!(idx)
                     )
                     .unwrap()
             })
@@ -507,8 +513,6 @@ pub unsafe fn handle_draw(layout: *mut Layout, draw_info: u64, cmd_buffer: u64) 
             });
         } else {
             let (_title, _help_text, gauge_vals) = app.sub_menu_strs_for_slider();
-            let abs_min = gauge_vals.abs_min;
-            let abs_max = gauge_vals.abs_max;
             let selected_min = gauge_vals.selected_min;
             let selected_max = gauge_vals.selected_max;
 
@@ -698,7 +702,6 @@ pub unsafe fn layout_build_parts_impl(
         if !HAS_CREATED_SLIDER_BG && (*block).name_matches("icn_bg_main") {
             (0..NUM_MENU_TEXT_SLIDERS).for_each(|index| {
                 let x = index % 2;
-                let y = index / 2;
             
                 if MENU_PANE_PTR != 0 {
                     let slider_root = (*(MENU_PANE_PTR as *mut Pane)).find_pane_by_name("slider_menu", true).unwrap();
@@ -714,11 +717,9 @@ pub unsafe fn layout_build_parts_impl(
                     pic_menu_block.picture.scale_x /= 1.85;
                     pic_menu_block.picture.scale_y /= 1.25;
 
-                    let y_offset = pic_menu_block.size_y / 2.0;
-
                     pic_menu_block.set_pos(ResVec3::new(
                         slider_root.pos_x - 842.5 + x_offset,
-                        slider_root.pos_y + (slider_bg.size_y * 0.458), // 137.5,
+                        slider_root.pos_y + slider_bg.size_y * 0.458,
                         0.0,
                     ));
 
@@ -734,15 +735,11 @@ pub unsafe fn layout_build_parts_impl(
         if !HAS_CREATED_SLIDER_BG_BACK && (*block).name_matches("btn_bg") {
             (0..NUM_MENU_TEXT_SLIDERS).for_each(|index| {
                 let x = index % 2;
-                let y = index / 2;
 
                 if MENU_PANE_PTR != 0 {
                     let slider_root = (*(MENU_PANE_PTR as *mut Pane)).find_pane_by_name("slider_menu", true).unwrap();
                     let slider_bg = (*(MENU_PANE_PTR as *mut Pane)).find_pane_by_name("slider_ui_container", true).unwrap();
 
-                    let size_x = slider_root.find_pane_by_name_recursive("slider_ui_container")
-                        .unwrap()
-                        .size_x * 0.9 / 2.0;
                     let size_y = 90.0;
 
                     let x_offset = x as f32 * 345.0;
@@ -760,11 +757,9 @@ pub unsafe fn layout_build_parts_impl(
 
                     bg_block.set_pos(ResVec3::new(
                         slider_root.pos_x - 700.0 + x_offset,
-                        slider_root.pos_y + (slider_bg.size_y * 0.458),
+                        slider_root.pos_y + slider_bg.size_y * 0.458,
                         0.0,
                     ));
-
-                    println!("button size y: {}", size_y);
 
                     let bg_pane = build!(bg_block, ResWindowWithTexCoordsAndFrames<1,4>, kind, Window);
                     bg_pane.detach();
@@ -1033,7 +1028,6 @@ pub unsafe fn layout_build_parts_impl(
 
     (0..NUM_MENU_TEXT_SLIDERS).for_each(|idx| {
         let x = idx % 2;
-        let y = idx / 2;
 
         let label_x_offset = x as f32 * 345.0;
 
@@ -1072,10 +1066,10 @@ pub unsafe fn layout_build_parts_impl(
 
             label_block.enable_shadow();
             label_block.text_alignment(TextAlignment::Center);
-            label_block.set_name(format!("{}_lbl", menu_text_slider_fmt!(idx)).as_str());
+            label_block.set_name(menu_slider_label_fmt!(idx));
             label_block.set_pos(ResVec3::new(
                 slider_root_pane.pos_x - 750.0 + label_x_offset,
-                slider_root_pane.pos_y + (slider_container.size_y * 0.458) + 5.0,
+                slider_root_pane.pos_y + slider_container.size_y * 0.458 + 5.0,
                 0.0,
             ));
             label_block.font_size = ResVec2::new(25.0, 50.0);

--- a/src/training/ui_hacks.rs
+++ b/src/training/ui_hacks.rs
@@ -107,16 +107,16 @@ const BG_LEFT_OFF_BLACK_COLOR: ResColor = ResColor {
 };
 
 const BG_LEFT_SELECTED_BLACK_COLOR: ResColor = ResColor {
-    r: 130,
-    g: 31,
-    b: 31,
+    r: 80,
+    g: 0,
+    b: 0,
     a: 0,
 };
 
 const BG_LEFT_SELECTED_WHITE_COLOR: ResColor = ResColor {
-    r: 145,
-    g: 33,
-    b: 33,
+    r: 118,
+    g: 0,
+    b: 0,
     a: 255,
 };
 
@@ -546,22 +546,8 @@ pub unsafe fn handle_draw(layout: *mut Layout, draw_info: u64, cmd_buffer: u64) 
                     match index {
                         0 => text_pane.set_text_string(&format!("{abs_min}")),
                         1 => text_pane.set_text_string(&format!("{abs_max}")),
-                        2 => {
-                            text_pane.set_text_string(&format!("{selected_min}"));
-                            match gauge_vals.state {
-                                GaugeState::MinHover => text_pane.set_color(200, 8, 8, 255),
-                                GaugeState::MinSelected => text_pane.set_color(8, 200, 8, 255),
-                                _ => text_pane.set_color(0, 0, 0, 255),
-                            }
-                        }
-                        3 => {
-                            text_pane.set_text_string(&format!("{selected_max}"));
-                            match gauge_vals.state {
-                                GaugeState::MaxHover => text_pane.set_color(200, 8, 8, 255),
-                                GaugeState::MaxSelected => text_pane.set_color(8, 200, 8, 255),
-                                _ => text_pane.set_color(0, 0, 0, 255),
-                            }
-                        }
+                        2 => text_pane.set_text_string(&format!("{selected_min}")),
+                        3 => text_pane.set_text_string(&format!("{selected_max}")),
                         _ => text_pane.set_text_string(""),
                     }
                 }
@@ -570,68 +556,47 @@ pub unsafe fn handle_draw(layout: *mut Layout, draw_info: u64, cmd_buffer: u64) 
                     .find_pane_by_name_recursive(format!("slider_btn_fg_{}", index).as_str())
                 {
                     let bg_left_material = &mut *bg_left.as_picture().material;
-                    match gauge_vals.state {
-                        GaugeState::MinHover | GaugeState::MinSelected => {
-                            bg_left_material.set_white_res_color(BG_LEFT_ON_WHITE_COLOR);
-                            bg_left_material.set_black_res_color(BG_LEFT_ON_BLACK_COLOR);
-                        }
+
+                    match index {
+                        2 => {
+                            match gauge_vals.state {
+                                GaugeState::MinHover => {
+                                    bg_left_material.set_white_res_color(BG_LEFT_ON_WHITE_COLOR);
+                                    bg_left_material.set_black_res_color(BG_LEFT_ON_BLACK_COLOR);
+                                },
+                                GaugeState::MinSelected => {
+                                    bg_left_material.set_white_res_color(BG_LEFT_SELECTED_WHITE_COLOR);
+                                    bg_left_material.set_black_res_color(BG_LEFT_SELECTED_BLACK_COLOR);
+                                },
+                                _ => {
+                                    bg_left_material.set_white_res_color(BG_LEFT_OFF_WHITE_COLOR);
+                                    bg_left_material.set_black_res_color(BG_LEFT_OFF_BLACK_COLOR);
+                                }
+                            }
+                        },
+                        3 => {
+                            match gauge_vals.state {
+                                GaugeState::MaxHover => {
+                                    bg_left_material.set_white_res_color(BG_LEFT_ON_WHITE_COLOR);
+                                    bg_left_material.set_black_res_color(BG_LEFT_ON_BLACK_COLOR);
+                                },
+                                GaugeState::MaxSelected => {
+                                    bg_left_material.set_white_res_color(BG_LEFT_SELECTED_WHITE_COLOR);
+                                    bg_left_material.set_black_res_color(BG_LEFT_SELECTED_BLACK_COLOR);
+                                },
+                                _ => {
+                                    bg_left_material.set_white_res_color(BG_LEFT_OFF_WHITE_COLOR);
+                                    bg_left_material.set_black_res_color(BG_LEFT_OFF_BLACK_COLOR);
+                                }
+                            }
+                        },
                         _ => {
                             bg_left_material.set_white_res_color(BG_LEFT_OFF_WHITE_COLOR);
                             bg_left_material.set_black_res_color(BG_LEFT_OFF_BLACK_COLOR);
                         }
                     }
-                    bg_left_material.set_white_res_color(BG_LEFT_ON_WHITE_COLOR);
-                    bg_left_material.set_black_res_color(BG_LEFT_ON_BLACK_COLOR);
                     bg_left.set_visible(true);
                 }
-                // if let Some(pic_pane) = root_pane.find_pane_by_name_recursive(format!("slider_btn_fg_{}", index).as_str()) {
-                //     let pic_pane = pic_pane.as_picture();
-                //     let pic_material = pic_pane.material.as_mut().unwrap();
-
-                //     pic_material.set_black_res_color(BG_LEFT_ON_BLACK_COLOR);
-                //     pic_material.set_white_res_color(BG_LEFT_SELECTED_WHITE_COLOR);
-                // match index {
-                //     2 => {
-                //         match gauge_vals.state {
-                //             GaugeState::MinHover => {
-                //                 pic_material.set_white_res_color(BG_LEFT_ON_WHITE_COLOR);
-                //                 pic_material.set_black_res_color(BG_LEFT_ON_BLACK_COLOR);
-                //             },
-                //             GaugeState::MinSelected => {
-                //                 println!("min, idx: 2 - sel");
-                //                 pic_material.set_white_res_color(BG_LEFT_SELECTED_WHITE_COLOR);
-                //                 pic_material.set_black_res_color(BG_LEFT_SELECTED_BLACK_COLOR);
-                //             },
-                //             _ => {
-                //                 pic_material.set_white_res_color(BG_LEFT_OFF_WHITE_COLOR);
-                //                 pic_material.set_black_res_color(BG_LEFT_OFF_BLACK_COLOR);
-                //             },
-                //         }
-                //     },
-                //     3 => {
-                //         match gauge_vals.state {
-                //             GaugeState::MaxHover => {
-                //                 pic_material.set_white_res_color(BG_LEFT_ON_WHITE_COLOR);
-                //                 pic_material.set_black_res_color(BG_LEFT_ON_BLACK_COLOR);
-                //             },
-                //             GaugeState::MaxSelected => {
-                //                 pic_material.set_white_res_color(BG_LEFT_SELECTED_WHITE_COLOR);
-                //                 pic_material.set_black_res_color(BG_LEFT_SELECTED_BLACK_COLOR);
-                //             },
-                //             _ => {
-                //                 pic_material.set_white_res_color(BG_LEFT_OFF_WHITE_COLOR);
-                //                 pic_material.set_black_res_color(BG_LEFT_OFF_BLACK_COLOR);
-                //             },
-                //         }
-                //     },
-                //     _ => {
-                //         pic_material.set_white_res_color(BG_LEFT_OFF_WHITE_COLOR);
-                //         pic_material.set_black_res_color(BG_LEFT_OFF_BLACK_COLOR);
-                //     }
-                // }
-
-                // pic_pane.set_visible(true);
-                // }
             });
         }
     }
@@ -642,6 +607,8 @@ pub unsafe fn handle_draw(layout: *mut Layout, draw_info: u64, cmd_buffer: u64) 
 pub static mut MENU_PANE_PTR: u64 = 0;
 pub static mut HAS_CREATED_OPT_BG: bool = false;
 pub static mut HAS_CREATED_OPT_BG_BACK: bool = false;
+pub static mut HAS_CREATED_SLIDER_BG: bool = false;
+pub static mut HAS_CREATED_SLIDER_BG_BACK: bool = false;
 
 #[skyline::hook(offset = 0x493a0)]
 pub unsafe fn layout_build_parts_impl(
@@ -732,15 +699,13 @@ pub unsafe fn layout_build_parts_impl(
             });
         }
 
-        (0..NUM_MENU_TEXT_SLIDERS).for_each(|index| {
-            let x = index % 2;
-            let y = index / 2;
-
-            if (*block).name_matches("icn_bg_main") {
+        if !HAS_CREATED_SLIDER_BG && (*block).name_matches("icn_bg_main") {
+            (0..NUM_MENU_TEXT_SLIDERS).for_each(|index| {
+                let x = index % 2;
+                let y = index / 2;
+            
                 if MENU_PANE_PTR != 0 {
-                    let slider_root = (*(MENU_PANE_PTR as *mut Pane))
-                        .find_pane_by_name("slider_menu", true)
-                        .unwrap();
+                    let slider_root = (*(MENU_PANE_PTR as *mut Pane)).find_pane_by_name("slider_menu", true).unwrap();
 
                     let x_offset = x as f32 * 345.0;
                     let y_offset = y as f32 * 125.0;
@@ -763,27 +728,25 @@ pub unsafe fn layout_build_parts_impl(
                     pic_menu_pane.detach();
 
                     slider_root.append_child(pic_menu_pane);
+                    HAS_CREATED_SLIDER_BG = true;
                 }
-            }
-            if (*block).name_matches("btn_bg") {
-                if MENU_PANE_PTR != 0 {
-                    let slider_root = (*(MENU_PANE_PTR as *mut Pane))
-                        .find_pane_by_name("slider_menu", true)
-                        .unwrap();
+            });
+        }
+        
+        if !HAS_CREATED_SLIDER_BG_BACK && (*block).name_matches("btn_bg") {
+            (0..NUM_MENU_TEXT_SLIDERS).for_each(|index| {
+                let x = index % 2;
+                let y = index / 2;
 
-                    let size_x = slider_root
-                        .find_pane_by_name_recursive("slider_ui_container")
+                if MENU_PANE_PTR != 0 {
+                    let slider_root = (*(MENU_PANE_PTR as *mut Pane)).find_pane_by_name("slider_menu", true).unwrap();
+
+                    let size_x = slider_root.find_pane_by_name_recursive("slider_ui_container")
                         .unwrap()
-                        .size_x
-                        * 0.9
-                        / 2.0;
-                    let size_y = (slider_root
-                        .find_pane_by_name_recursive("slider_ui_container")
+                        .size_x * 0.9 / 2.0;
+                    let size_y = (slider_root.find_pane_by_name_recursive("slider_ui_container")
                         .unwrap()
-                        .size_y
-                        * 0.50
-                        - 20.0)
-                        / 2.0;
+                        .size_y * 0.50 - 20.0) / 2.0;
 
                     println!("x: 450.0, y: {}", size_y);
 
@@ -796,7 +759,10 @@ pub unsafe fn layout_build_parts_impl(
                     bg_block.set_name(format!("slider_item_btn_{}", index).as_str());
                     bg_block.scale_x /= 2.0;
 
-                    bg_block.set_size(ResVec2::new(605.0, size_y));
+                    bg_block.set_size(ResVec2::new(
+                        605.0,
+                        size_y
+                    ));
 
                     bg_block.set_pos(ResVec3::new(
                         slider_root.pos_x - 700.0 + x_offset,
@@ -804,14 +770,14 @@ pub unsafe fn layout_build_parts_impl(
                         0.0,
                     ));
 
-                    let bg_pane =
-                        build!(bg_block, ResWindowWithTexCoordsAndFrames<1,4>, kind, Window);
+                    let bg_pane = build!(bg_block, ResWindowWithTexCoordsAndFrames<1,4>, kind, Window);
                     bg_pane.detach();
 
                     slider_root.append_child(bg_pane);
+                    HAS_CREATED_SLIDER_BG_BACK = true;
                 }
-            }
-        });
+            });
+        }
     }
 
     if layout_name != "info_training" {
@@ -842,6 +808,8 @@ pub unsafe fn layout_build_parts_impl(
             HAS_CREATED_OPT_BG = false;
             HAS_CREATED_OPT_BG_BACK = false;
             HAS_SORTED_MENU_CHILDREN = false;
+            HAS_CREATED_SLIDER_BG = false;
+            HAS_CREATED_SLIDER_BG_BACK = false;
         }
     }
 


### PR DESCRIPTION
Added a UI for the slider type settings in the new ui2d quick menu.

The design for this layout can be found [here](https://www.figma.com/file/J5Paft3HxAVL0wwvODmBxW/Quick-Menu?node-id=0%3A1&t=dB2NToGEOjh1guCU-0) in the panel titled `Slider`.

As per CPU's feedback I've removed the `Min`/`Max` + `Current Min`/`Current Max` layout in favour of having just `Min`/`Max` with the values editable and capped to the `abs_min` and `abs_max` respectively.