### PR TITLE
update infinite shield logic

### DIFF
--- a/src/training/mod.rs
+++ b/src/training/mod.rs
@@ -86,6 +86,9 @@ pub unsafe fn handle_get_command_flag_cat(
 ) -> i32 {
     let mut flag = original!()(module_accessor, category);
 
+    // this must be run even outside of training mode
+    // because otherwise it won't reset the shield_damage_mul
+    // back to "normal" once you leave training mode.
     if category == FIGHTER_PAD_COMMAND_CATEGORY1 {
         shield::param_installer();
     }

--- a/src/training/shield.rs
+++ b/src/training/shield.rs
@@ -145,13 +145,33 @@ fn handle_shield_decay(param_type: u64, param_hash: u64) -> Option<f32> {
     None
 }
 
+/// This is the cached shield damage multiplier.
+/// Vanilla is 1.19, but mods can change this.
+static mut CACHED_SHIELD_DAMAGE_MUL: f32 = -1.0;
+
+
+/// sets/resets the shield_damage_mul within 
+/// the game's internal structure. 
+/// 
+/// `common_params` is effectively a mutable reference
+/// to the game's own internal data structure for params.
 pub unsafe fn param_installer() {
     if crate::training::COMMON_PARAMS as usize != 0 {
         let common_params = &mut *crate::training::COMMON_PARAMS;
+
+        // cache the original shield damage multiplier once
+        if ORIGINAL_SHIELD_DAMAGE_MUL < 0.0 {
+            ORIGINAL_SHIELD_DAMAGE_MUL = common_params.shield_damage_mul;
+        }
+
         if is_training_mode() && (MENU.shield_state == Shield::Infinite) {
+            // if you are in training mode and have infinite shield enabled,
+            // set the game's shield_damage_mul to 0.0
             common_params.shield_damage_mul = 0.0;
         } else {
-            common_params.shield_damage_mul = 1.19;
+            // reset the game's shield_damage_mul back to what
+            // it originally was at game boot.
+            common_params.shield_damage_mul = CACHED_SHIELD_DAMAGE_MUL;
         }
     }
 }

--- a/src/training/shield.rs
+++ b/src/training/shield.rs
@@ -147,7 +147,7 @@ fn handle_shield_decay(param_type: u64, param_hash: u64) -> Option<f32> {
 
 /// This is the cached shield damage multiplier.
 /// Vanilla is 1.19, but mods can change this.
-static mut CACHED_SHIELD_DAMAGE_MUL: f32 = -1.0;
+static mut CACHED_SHIELD_DAMAGE_MUL: Option<f32> = None;
 
 
 /// sets/resets the shield_damage_mul within 
@@ -160,8 +160,8 @@ pub unsafe fn param_installer() {
         let common_params = &mut *crate::training::COMMON_PARAMS;
 
         // cache the original shield damage multiplier once
-        if ORIGINAL_SHIELD_DAMAGE_MUL < 0.0 {
-            ORIGINAL_SHIELD_DAMAGE_MUL = common_params.shield_damage_mul;
+        if CACHED_SHIELD_DAMAGE_MUL.is_none() {
+            CACHED_SHIELD_DAMAGE_MUL = Some(common_params.shield_damage_mul);
         }
 
         if is_training_mode() && (MENU.shield_state == Shield::Infinite) {
@@ -171,7 +171,7 @@ pub unsafe fn param_installer() {
         } else {
             // reset the game's shield_damage_mul back to what
             // it originally was at game boot.
-            common_params.shield_damage_mul = CACHED_SHIELD_DAMAGE_MUL;
+            common_params.shield_damage_mul = CACHED_SHIELD_DAMAGE_MUL.unwrap();
         }
     }
 }


### PR DESCRIPTION
This updates the shield logic to use the originally loaded shield damage mul param rather than a hardcoded vanilla param that may be different than what the game (read: mods) had loaded initially.