### PR TITLE
Resolve Panic on Ryujinx

### DIFF
--- a/src/common/menu.rs
+++ b/src/common/menu.rs
@@ -21,7 +21,9 @@ pub fn init() {
     unsafe {
         FRAME_COUNTER_INDEX = frame_counter::register_counter();
         QUICK_MENU_FRAME_COUNTER_INDEX = frame_counter::register_counter();
-        write_menu();
+        if !is_emulator() {
+            write_web_menu_file();
+        }
     }
 }
 
@@ -43,7 +45,7 @@ pub unsafe fn menu_condition(module_accessor: &mut smash::app::BattleObjectModul
     }
 }
 
-pub unsafe fn write_menu() {
+pub unsafe fn write_web_menu_file() {
     let tpl = Template::new(include_str!("../templates/menu.html")).unwrap();
 
     let overall_menu = get_menu();


### PR DESCRIPTION
PR #459 exposed an error that was being silently ignored on Ryujinx when writing the web html file. That PR changed the error to be a panic, and prevents Ryujinx users from using the current version of the modpack. This PR changes the logic so that we only attempt to write this file when on console.