### PR TITLE
Developer TOML for hot-reloading configs

### DIFF
--- a/src/common/dev_config.rs
+++ b/src/common/dev_config.rs
@@ -68,6 +68,6 @@ pub fn handle_get_npad_state(state: *mut NpadGcState, _controller_id: *const u32
 
             let mut dev_config = DEV_CONFIG.lock();
             *dev_config = DevConfig::load_from_toml();
-        }
+
     }
 }

--- a/src/common/dev_config.rs
+++ b/src/common/dev_config.rs
@@ -32,7 +32,7 @@ use toml;
 pub struct DevConfig {
 }
 
-pub fn config() -> &DevConfig {
+pub fn config() -> &'static DevConfig {
     &*DEV_CONFIG.data_ptr()
 }
 

--- a/src/common/dev_config.rs
+++ b/src/common/dev_config.rs
@@ -32,7 +32,7 @@ use toml;
 pub struct DevConfig {
 }
 
-pub unsafe config() -> &'static DevConfig {
+pub unsafe fn config() -> &'static DevConfig {
     &*DEV_CONFIG.data_ptr()
 }
 

--- a/src/common/dev_config.rs
+++ b/src/common/dev_config.rs
@@ -24,9 +24,9 @@ use toml;
 ///
 /// In another file such as `ui2d/menu.rs`:
 /// ```rust
-/// let dev_config = crate::dev_config::DEV_CONFIG.data_ptr();
-/// quit_menu_button.pos_y = (*dev_config).quit_menu_pos_y;
-/// quit_menu_text.as_textbox().set_text_string(&(*dev_config).quit_menu_title);
+/// let dev_config = crate::dev_config::config();
+/// quit_menu_button.pos_y = dev_config.quit_menu_pos_y;
+/// quit_menu_text.as_textbox().set_text_string(&dev_config.quit_menu_title);
 /// ```
 #[derive(Deserialize, Default)]
 pub struct DevConfig {
@@ -44,12 +44,9 @@ lazy_static! {
 impl DevConfig {
     fn load_from_toml() -> DevConfig {
         let dev_path = "sd:/TrainingModpack/dev.toml";
-
         if fs::metadata(dev_path).is_ok() {
-
             info!("Loading dev.toml configs...");
             let dev_config_str = fs::read_to_string(dev_path).unwrap_or_else(|_| panic!("Could not read {}", dev_path));
-            
             return toml::from_str(&dev_config_str).expect("Could not parse dev config");
         }
         
@@ -68,10 +65,7 @@ pub fn handle_get_npad_state(state: *mut NpadGcState, _controller_id: *const u32
 
     // Occurs on L+R+A
     if (buttons & a_press > 0) && (buttons & l_press > 0) && (buttons & r_press > 0) {
-
-
-            let mut dev_config = DEV_CONFIG.lock();
-            *dev_config = DevConfig::load_from_toml();
-
+        let mut dev_config = DEV_CONFIG.lock();
+        *dev_config = DevConfig::load_from_toml();
     }
 }

--- a/src/common/dev_config.rs
+++ b/src/common/dev_config.rs
@@ -1,0 +1,60 @@
+use lazy_static::lazy_static;
+use parking_lot::Mutex;
+use serde::Deserialize;
+use skyline::nn::hid::NpadGcState;
+use crate::logging::info;
+use std::fs;
+use toml;
+
+
+/// Hot-reloadable configs for quicker development
+///
+/// In game, press L+R+A at any point to reread these configs from
+/// the file in sd:/TrainingModpack/dev.toml
+///
+/// Example usage:
+///
+/// In this file:
+/// ```rust
+/// pub struct DevConfig {
+///     pub quit_menu_title: String,
+///     pub quit_menu_pos_y: i32,
+/// }
+/// ```
+///
+/// In another file such as `ui2d/menu.rs`:
+/// ```rust
+/// let dev_config = crate::dev_config::DEV_CONFIG.data_ptr();
+/// quit_menu_button.pos_y = (*dev_config).quit_menu_pos_y;
+/// quit_menu_text.as_textbox().set_text_string(&(*dev_config).quit_menu_title);
+/// ```
+#[derive(Deserialize, Default)]
+pub struct DevConfig {
+}
+
+lazy_static! {
+    pub static ref DEV_CONFIG : Mutex<DevConfig> = Mutex::new(DevConfig::default());
+    pub static ref DEV_CONFIG_STR : Mutex<String> = Mutex::new("".to_string());
+}
+
+pub fn handle_get_npad_state(state: *mut NpadGcState, _controller_id: *const u32) {
+    let a_press = 1 << 0;
+    let l_press = 1 << 6;
+    let r_press = 1 << 7;
+    let buttons;
+    unsafe {
+        buttons = (*state).Buttons;
+    }
+
+    // Occurs on L+R+A
+    if (buttons & a_press > 0) && (buttons & l_press > 0) && (buttons & r_press > 0) {
+        let dev_path = "sd:/TrainingModpack/dev.toml";
+        if fs::metadata(dev_path).is_ok() {
+            info!("Loading dev.toml configs...");
+            let mut dev_config_str = DEV_CONFIG_STR.lock();
+            *dev_config_str = fs::read_to_string(dev_path).unwrap_or_else(|_| panic!("Could not remove {}", dev_path));
+            let mut dev_config = DEV_CONFIG.lock();
+            *dev_config = toml::from_str(&dev_config_str).expect("Could not parse dev config");
+        }
+    }
+}

--- a/src/common/dev_config.rs
+++ b/src/common/dev_config.rs
@@ -32,6 +32,10 @@ use toml;
 pub struct DevConfig {
 }
 
+pun fn config() -> &DevConfig {
+    &*DEV_CONFIG.data_ptr()
+}
+
 lazy_static! {
     pub static ref DEV_CONFIG : Mutex<DevConfig> = Mutex::new(DevConfig::load_from_toml());
     pub static ref DEV_CONFIG_STR : Mutex<String> = Mutex::new("".to_string());

--- a/src/common/dev_config.rs
+++ b/src/common/dev_config.rs
@@ -32,7 +32,7 @@ use toml;
 pub struct DevConfig {
 }
 
-pun fn config() -> &DevConfig {
+pub fn config() -> &DevConfig {
     &*DEV_CONFIG.data_ptr()
 }
 

--- a/src/common/dev_config.rs
+++ b/src/common/dev_config.rs
@@ -32,7 +32,7 @@ use toml;
 pub struct DevConfig {
 }
 
-pub fn config() -> &'static DevConfig {
+pub unsafe config() -> &'static DevConfig {
     &*DEV_CONFIG.data_ptr()
 }
 

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -4,6 +4,7 @@ pub mod events;
 pub mod menu;
 pub mod raygun_printer;
 pub mod release;
+pub mod dev_config;
 
 use crate::common::consts::*;
 use smash::app::{self, lua_bind::*};

--- a/src/training/mod.rs
+++ b/src/training/mod.rs
@@ -1,6 +1,4 @@
-use crate::common::{
-    is_training_mode, menu, FIGHTER_MANAGER_ADDR, ITEM_MANAGER_ADDR, STAGE_MANAGER_ADDR,
-};
+use crate::common::{is_training_mode, menu, FIGHTER_MANAGER_ADDR, ITEM_MANAGER_ADDR, STAGE_MANAGER_ADDR, dev_config};
 use crate::hitbox_visualizer;
 use crate::logging::*;
 use crate::training::character_specific::items;
@@ -482,13 +480,14 @@ extern "C" {
 pub fn training_mods() {
     info!("Applying training mods.");
 
-    // Input Recording/Delay
+    // Input Mods
     unsafe {
         if (add_nn_hid_hook as *const ()).is_null() {
             panic!("The NN-HID hook plugin could not be found and is required to add NRO hooks. Make sure libnn_hid_hook.nro is installed.");
         }
         add_nn_hid_hook(input_delay::handle_get_npad_state);
         add_nn_hid_hook(menu::handle_get_npad_state);
+        add_nn_hid_hook(dev_config::handle_get_npad_state);
     }
 
     unsafe {


### PR DESCRIPTION
Docstring copypaste:

> Hot-reloadable configs for quicker development
>
> In game, press L+R+A at any point to reread these configs from
> the file in sd:/TrainingModpack/dev.toml
>
> Example usage:
>
> In this file:
> ```rust
> pub struct DevConfig {
>     pub quit_menu_title: String,
>     pub quit_menu_pos_y: i32,
> }
> ```
>
> In another file such as `ui2d/menu.rs`:
> ```rust
> let dev_config = crate::dev_config::config();
> quit_menu_button.pos_y = dev_config.quit_menu_pos_y;
> quit_menu_text.as_textbox().set_text_string(&dev_config.quit_menu_title);
> ```