### PR TITLE
Bugfix: Pressing A on active option for single option toggle unchecks it

### DIFF
--- a/training_mod_tui/src/lib.rs
+++ b/training_mod_tui/src/lib.rs
@@ -323,6 +323,7 @@ impl<'a> App<'a> {
                                     if !o.checked {
                                         o.checked = true;
                                     } else {
+                                        if is_single_option { return; }
                                         o.checked = false;
                                     }
                                 } else if is_single_option {
@@ -340,6 +341,7 @@ impl<'a> App<'a> {
                                 if !o.checked {
                                     o.checked = true;
                                 } else {
+                                    if is_single_option { return; }
                                     o.checked = false;
                                 }
                             } else if is_single_option {


### PR DESCRIPTION
## Changes
Fixed the A button handling to early out if the clicked option is already checked and the toggle's `is_single_option` flas is set to `true`