### PR TITLE
Fix climber death

### DIFF
--- a/src/training/save_states.rs
+++ b/src/training/save_states.rs
@@ -413,12 +413,10 @@ pub unsafe fn save_states(module_accessor: &mut app::BattleObjectModuleAccessor)
     }
 
     // Kill the fighter and move them to camera bounds
-    if save_state.state == KillPlayer {
+    if save_state.state == KillPlayer && !fighter_is_nana {
+        // Don't kill Nana again, since she already gets killed by the game from Popo's death 
         on_ptrainer_death(module_accessor);
-        if !is_dead(module_accessor) &&
-            // Don't kill Nana again, since she already gets killed by the game from Popo's death
-            !fighter_is_nana
-        {
+        if !is_dead(module_accessor) {
             on_death(fighter_kind, module_accessor);
             StatusModule::change_status_request(module_accessor, *FIGHTER_STATUS_KIND_DEAD, false);
         }


### PR DESCRIPTION
Addresses an issue added with save state slots that causes save states to not work with Player Ice Climbers