### PR TITLE
Update Rust toolchain override file

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,0 @@
-nightly

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"


### PR DESCRIPTION
While reading through [Overrides - The rustup book](https://rust-lang.github.io/rustup/overrides.html) I noticed we don't use the 'modern' method of specifying the channel for the Rust toolchain. This PR introduces no change to the underlying functionality.