### PR TITLE
Fix clippy CI: once_cell is stabilized

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
 #![feature(proc_macro_hygiene)]
 #![feature(const_mut_refs)]
 #![feature(exclusive_range_pattern)]
-#![feature(once_cell)]
 #![feature(c_variadic)]
 #![allow(
     clippy::borrow_interior_mutable_const,


### PR DESCRIPTION
Clippy is complaining about the 'once_cell' feature now being stable, so we can just remove the feature flag.