### PR TITLE
Input Recording in Button Config

### DIFF
--- a/src/common/button_config.rs
+++ b/src/common/button_config.rs
@@ -40,6 +40,14 @@ static mut BUTTON_COMBO_CONFIG: BtnComboConfig = BtnComboConfig {
         hold: vec![],
         press: vec![],
     },
+    input_record: BtnList {
+        hold: vec![],
+        press: vec![],
+    },
+    input_playback: BtnList {
+        hold: vec![],
+        press: vec![],
+    },
 };
 
 #[derive(Debug, EnumIter, PartialEq)]
@@ -47,6 +55,8 @@ pub enum ButtonCombo {
     OpenMenu,
     SaveState,
     LoadState,
+    InputRecord,
+    InputPlayback,
 }
 
 #[derive(Deserialize, Default)]
@@ -60,6 +70,8 @@ struct BtnComboConfig {
     open_menu: BtnList,
     save_state: BtnList,
     load_state: BtnList,
+    input_record: BtnList,
+    input_playback: BtnList,
 }
 
 #[derive(Deserialize)]
@@ -105,6 +117,14 @@ fn save_all_btn_config_from_defaults() {
             load_state: BtnList {
                 hold: vec!["SHIELD".to_string()],
                 press: vec!["UPTAUNT".to_string()],
+            },
+            input_record: BtnList {
+                hold: vec!["ATTACK".to_string()],
+                press: vec!["LEFTTAUNT".to_string()],
+            },
+            input_playback: BtnList {
+                hold: vec!["ATTACK".to_string()],
+                press: vec!["RIGHTTAUNT".to_string()],
             },
         },
     };
@@ -170,6 +190,14 @@ unsafe fn get_combo_keys(combo: ButtonCombo) -> (&'static Vec<String>, &'static 
             &BUTTON_COMBO_CONFIG.load_state.hold,
             &BUTTON_COMBO_CONFIG.load_state.press,
         ),
+        ButtonCombo::InputRecord => (
+            &BUTTON_COMBO_CONFIG.input_record.hold,
+            &BUTTON_COMBO_CONFIG.input_record.press,
+        ),
+        ButtonCombo::InputPlayback => (
+            &BUTTON_COMBO_CONFIG.input_playback.hold,
+            &BUTTON_COMBO_CONFIG.input_playback.press,
+        ),
     }
 }
 
@@ -234,4 +262,12 @@ press=["DOWNTAUNT",]
 [button_config.load_state]
 hold=["SHIELD",]
 press=["UPTAUNT",]
+
+[button_config.input_record]
+hold=["ATTACK",]
+press=["LEFTTAUNT",]
+
+[button_config.input_playback]
+hold=["ATTACK",]
+press=["RIGHTTAUNT",]
 "#;

--- a/src/training/input_record.rs
+++ b/src/training/input_record.rs
@@ -1,4 +1,5 @@
-use crate::common::consts::{FighterId, HitstunPlayback, RecordTrigger};
+use crate::common::button_config;
+use crate::common::consts::{FighterId, HitstunPlayback};
 use crate::common::{get_module_accessor, is_in_hitstun, is_in_shieldstun, MENU};
 use crate::training::input_recording::structures::*;
 use crate::training::mash;
@@ -177,19 +178,19 @@ pub unsafe fn get_command_flag_cat(module_accessor: &mut BattleObjectModuleAcces
     CURRENT_RECORD_SLOT = MENU.recording_slot.into_idx();
 
     if entry_id_int == 0 && !fighter_is_nana {
-        // Attack + Dpad Right: Playback
-        if ControlModule::check_button_on(module_accessor, *CONTROL_PAD_BUTTON_ATTACK)
-            && ControlModule::check_button_trigger(module_accessor, *CONTROL_PAD_BUTTON_APPEAL_S_R)
-        {
+        if button_config::combo_passes_exclusive(
+            module_accessor,
+            button_config::ButtonCombo::InputPlayback,
+        ) {
             //crate::common::raygun_printer::print_string(&mut *module_accessor, "PLAYBACK");
             playback();
             println!("Playback Command Received!"); //debug
         }
         // Attack + Dpad Left: Record
-        else if ControlModule::check_button_on(module_accessor, *CONTROL_PAD_BUTTON_ATTACK)
-            && ControlModule::check_button_trigger(module_accessor, *CONTROL_PAD_BUTTON_APPEAL_S_L)
-            && MENU.record_trigger == RecordTrigger::Command
-        {
+        else if button_config::combo_passes_exclusive(
+            module_accessor,
+            button_config::ButtonCombo::InputRecord,
+        ) {
             //crate::common::raygun_printer::print_string(&mut *module_accessor, "RECORDING");
             lockout_record();
             println!("Record Command Received!"); //debug

--- a/src/training/input_record.rs
+++ b/src/training/input_record.rs
@@ -271,7 +271,11 @@ pub unsafe fn playback() {
         println!("Tried to playback during lockout!");
         return;
     }
-    CURRENT_PLAYBACK_SLOT = MENU.playback_slot.get_random().into_idx().unwrap();
+    if MENU.playback_slot.is_empty() {
+        println!("Tried to playback without a slot selected!");
+        return;
+    }
+    CURRENT_PLAYBACK_SLOT = MENU.playback_slot.get_random().into_idx().unwrap_or(0);
     INPUT_RECORD = Playback;
     POSSESSION = Player;
     INPUT_RECORD_FRAME = 0;
@@ -317,7 +321,9 @@ pub unsafe fn is_end_standby() -> bool {
     let clamped_rstick_y =
         ((first_frame_input.rstick_y as f32) * STICK_CLAMP_MULTIPLIER).clamp(-1.0, 1.0);
 
-    let buttons_pressed = !first_frame_input.buttons.is_empty();
+    // No buttons pressed or just flick jump-- if they really did a stick jump, we'd have lstick movement as well
+    let buttons_pressed =
+        !(first_frame_input.buttons.is_empty() || first_frame_input.buttons == Buttons::FLICK_JUMP);
     let lstick_movement =
         clamped_lstick_x.abs() >= STICK_NEUTRAL || clamped_lstick_y.abs() >= STICK_NEUTRAL;
     let rstick_movement =

--- a/src/training/input_record.rs
+++ b/src/training/input_record.rs
@@ -2,8 +2,10 @@ use crate::common::consts::{FighterId, HitstunPlayback, RecordTrigger};
 use crate::common::{get_module_accessor, is_in_hitstun, is_in_shieldstun, MENU};
 use crate::training::input_recording::structures::*;
 use crate::training::mash;
+use crate::training::ui::notifications::{clear_notifications, color_notification};
 use lazy_static::lazy_static;
 use parking_lot::Mutex;
+use skyline::nn::ui2d::ResColor;
 use smash::app::{lua_bind::*, utility, BattleObjectModuleAccessor};
 use smash::lib::lua_const::*;
 use std::cmp::Ordering;
@@ -207,8 +209,19 @@ pub unsafe fn get_command_flag_cat(module_accessor: &mut BattleObjectModuleAcces
     }
 
     // Handle Possession Coloring
-    //let model_color_type = *MODEL_COLOR_TYPE_COLOR_BLEND;
     if entry_id_int == 1 && POSSESSION == Lockout {
+        clear_notifications("Input Recording");
+        color_notification(
+            "Input Recording".to_string(),
+            "Lockout".to_owned(),
+            60,
+            ResColor {
+                r: 200,
+                g: 8,
+                b: 8,
+                a: 255,
+            },
+        );
         set_color_rgb_2(
             module_accessor,
             0.0,
@@ -217,6 +230,18 @@ pub unsafe fn get_command_flag_cat(module_accessor: &mut BattleObjectModuleAcces
             *MODEL_COLOR_TYPE_COLOR_BLEND,
         );
     } else if entry_id_int == 1 && POSSESSION == Standby {
+        clear_notifications("Input Recording");
+        color_notification(
+            "Input Recording".to_string(),
+            "Standby".to_owned(),
+            60,
+            ResColor {
+                r: 200,
+                g: 8,
+                b: 200,
+                a: 255,
+            },
+        );
         set_color_rgb_2(
             module_accessor,
             1.0,
@@ -225,6 +250,18 @@ pub unsafe fn get_command_flag_cat(module_accessor: &mut BattleObjectModuleAcces
             *MODEL_COLOR_TYPE_COLOR_BLEND,
         );
     } else if entry_id_int == 1 && POSSESSION == Cpu {
+        clear_notifications("Input Recording");
+        color_notification(
+            "Input Recording".to_string(),
+            "Recording".to_owned(),
+            60,
+            ResColor {
+                r: 200,
+                g: 8,
+                b: 8,
+                a: 255,
+            },
+        );
         set_color_rgb_2(
             module_accessor,
             1.0,
@@ -275,6 +312,20 @@ pub unsafe fn playback() {
         println!("Tried to playback without a slot selected!");
         return;
     }
+
+    clear_notifications("Input Recording");
+    color_notification(
+        "Input Recording".to_string(),
+        "Playback".to_owned(),
+        60,
+        ResColor {
+            r: 0,
+            g: 0,
+            b: 0,
+            a: 255,
+        },
+    );
+
     CURRENT_PLAYBACK_SLOT = MENU.playback_slot.get_random().into_idx().unwrap_or(0);
     INPUT_RECORD = Playback;
     POSSESSION = Player;
@@ -289,6 +340,26 @@ pub unsafe fn playback_ledge() {
         println!("Tried to playback during lockout!");
         return;
     }
+    if MENU.playback_slot.is_empty() {
+        println!("Tried to playback without a slot selected!");
+        return;
+    }
+
+    clear_notifications("Input Recording");
+    color_notification(
+        "Input Recording".to_string(),
+        "Playback".to_owned(),
+        60,
+        ResColor {
+            r: 0,
+            g: 0,
+            b: 0,
+            a: 255,
+        },
+    );
+
+    CURRENT_PLAYBACK_SLOT = MENU.playback_slot.get_random().into_idx().unwrap_or(0);
+
     INPUT_RECORD = Playback;
     POSSESSION = Player;
     INPUT_RECORD_FRAME = 0;


### PR DESCRIPTION
Closes https://github.com/jugeeya/UltimateTrainingModpack/issues/549 . Keeping as `ATTACK+Taunt Left/right` so as to not trigger accidental pushes from save state which also uses shield+taunt.