### PR TITLE
Fix builds of modpack on M1 Mac

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -50,8 +50,7 @@ jobs:
         with:
           target: x86_64-unknown-linux-gnu
       - name: Install Skyline
-        run: |
-          cargo install cargo-skyline
+        run: cargo install cargo-skyline
       - name: Build release NRO
         id: build_release
         run: cargo-skyline skyline build --release

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -49,6 +49,11 @@ jobs:
       - uses: dtolnay/rust-toolchain@nightly
         with:
           target: x86_64-unknown-linux-gnu
+      - uses: Swatinem/rust-cache@v2
+        name: Rust Cache
+        with:
+          prefix-key: "plugin"
+          cache-all-crates: true
       - name: Install Skyline
         run: cargo install cargo-skyline
       - name: Build release NRO
@@ -63,14 +68,18 @@ jobs:
     name: Plugin NRO (Outside Training Mode)
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    container:
-      image: jugeeya/cargo-skyline:3.2.0-no-dkp
     steps:
       - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          target: x86_64-unknown-linux-gnu
       - uses: Swatinem/rust-cache@v2
         name: Rust Cache
         with:
           prefix-key: "plugin"
+          cache-all-crates: true
+      - name: Install Skyline
+        run: cargo install cargo-skyline
       - name: Build outside_training_mode NRO
         run: cargo-skyline skyline build --release --features outside_training_mode
         env:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -45,14 +45,15 @@ jobs:
   plugin:
     name: Plugin NRO
     runs-on: ubuntu-latest
-    container:
-      image: jugeeya/cargo-skyline:3.2.0-no-dkp
     steps:
       - uses: actions/checkout@v3
-      - uses: Swatinem/rust-cache@v2
-        name: Rust Cache
+      - uses: dtolnay/rust-toolchain@nightly
         with:
-          prefix-key: "plugin"
+          target: x86_64-unknown-linux-gnu
+      - name: Install Skyline
+        run: |
+          cargo install cargo-skyline
+          cargo skyline update-std
       - name: Build release NRO
         id: build_release
         run: cargo-skyline skyline build --release

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -86,8 +86,6 @@ jobs:
           cargo-skyline skyline update-std
       - name: Build outside_training_mode NRO
         run: cargo-skyline skyline build --release --features outside_training_mode
-        env:
-          HOME: /root
       - name: Upload plugin (outside training mode) artifact
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -35,7 +35,8 @@ jobs:
         with:
           prefix-key: "checker-2"
       - name: Clippy
-        run: cargo install cargo-skyline && cargo skyline update-std && cargo clippy --all-targets --all-features --target=x86_64-unknown-linux-gnu -- -D warnings
+        run: |
+          cargo clippy --all-targets --all-features --target=x86_64-unknown-linux-gnu -- -D warnings
       - name: TUI Test
         uses: ClementTsang/cargo-action@v0.0.3
         with:
@@ -54,7 +55,7 @@ jobs:
           prefix-key: "plugin"
       - name: Build release NRO
         id: build_release
-        run: cargo skyline update-std && cargo-skyline skyline build --release
+        run: cargo skyline build --release
         env:
           HOME: /root
       - name: Upload plugin artifact

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           prefix-key: "checker-2"
       - name: Clippy
-        run: cargo clippy --all-targets --all-features --target=x86_64-unknown-linux-gnu -- -D warnings
+        run: cargo skyline update-std && cargo clippy --all-targets --all-features --target=x86_64-unknown-linux-gnu -- -D warnings
       - name: TUI Test
         uses: ClementTsang/cargo-action@v0.0.3
         with:
@@ -54,7 +54,7 @@ jobs:
           prefix-key: "plugin"
       - name: Build release NRO
         id: build_release
-        run: cargo-skyline skyline build --release
+        run: cargo skyline update-std && cargo-skyline skyline build --release
         env:
           HOME: /root
       - name: Upload plugin artifact

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -53,12 +53,10 @@ jobs:
       - name: Install Skyline
         run: |
           cargo install cargo-skyline
-          cargo skyline update-std
+          cargo-skyline skyline update-std
       - name: Build release NRO
         id: build_release
         run: cargo-skyline skyline build --release
-        env:
-          HOME: /root
       - name: Upload plugin artifact
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -35,8 +35,7 @@ jobs:
         with:
           prefix-key: "checker-2"
       - name: Clippy
-        run: |
-          cargo clippy --all-targets --all-features --target=x86_64-unknown-linux-gnu -- -D warnings
+        run: cargo clippy --all-targets --all-features --target=x86_64-unknown-linux-gnu -- -D warnings
       - name: TUI Test
         uses: ClementTsang/cargo-action@v0.0.3
         with:
@@ -53,7 +52,6 @@ jobs:
       - name: Install Skyline
         run: |
           cargo install cargo-skyline
-          cargo-skyline skyline update-std
       - name: Build release NRO
         id: build_release
         run: cargo-skyline skyline build --release

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           prefix-key: "checker-2"
       - name: Clippy
-        run: cargo skyline update-std && cargo clippy --all-targets --all-features --target=x86_64-unknown-linux-gnu -- -D warnings
+        run: cargo install cargo-skyline && cargo skyline update-std && cargo clippy --all-targets --all-features --target=x86_64-unknown-linux-gnu -- -D warnings
       - name: TUI Test
         uses: ClementTsang/cargo-action@v0.0.3
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -76,8 +76,7 @@ jobs:
         with:
           prefix-key: "plugin"
       - name: Build outside_training_mode NRO
-        run: |
-          cargo-skyline skyline build --release --features outside_training_mode
+        run: cargo-skyline skyline build --release --features outside_training_mode
         env:
           HOME: /root
       - name: Upload plugin (outside training mode) artifact

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -55,7 +55,7 @@ jobs:
           prefix-key: "plugin"
       - name: Build release NRO
         id: build_release
-        run: cargo skyline build --release
+        run: cargo-skyline skyline build --release
         env:
           HOME: /root
       - name: Upload plugin artifact

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -55,7 +55,9 @@ jobs:
           prefix-key: "plugin"
           cache-all-crates: true
       - name: Install Skyline
-        run: cargo install cargo-skyline
+        run: |
+          cargo install cargo-skyline
+          cargo-skyline skyline update-std
       - name: Build release NRO
         id: build_release
         run: cargo-skyline skyline build --release
@@ -79,7 +81,9 @@ jobs:
           prefix-key: "plugin"
           cache-all-crates: true
       - name: Install Skyline
-        run: cargo install cargo-skyline
+        run: |
+          cargo install cargo-skyline
+          cargo-skyline skyline update-std
       - name: Build outside_training_mode NRO
         run: cargo-skyline skyline build --release --features outside_training_mode
         env:

--- a/src/common/events.rs
+++ b/src/common/events.rs
@@ -1,10 +1,9 @@
 use std::convert::TryInto;
+use std::ffi::{c_char,c_void};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
-use skyline::libc;
-use skyline::libc::c_void;
 use skyline::nn::{account, oe, time};
 
 use crate::common::release::CURRENT_VERSION;
@@ -181,7 +180,7 @@ pub fn smash_version() -> String {
     unsafe {
         oe::GetDisplayVersion(&mut smash_version);
 
-        std::ffi::CStr::from_ptr(smash_version.name.as_ptr() as *const libc::c_char)
+        std::ffi::CStr::from_ptr(smash_version.name.as_ptr() as *const c_char)
             .to_string_lossy()
             .into_owned()
     }

--- a/src/common/events.rs
+++ b/src/common/events.rs
@@ -1,5 +1,5 @@
 use std::convert::TryInto;
-use std::ffi::{c_char,c_void};
+use std::ffi::{c_char, c_void};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use once_cell::sync::OnceCell;

--- a/src/common/events.rs
+++ b/src/common/events.rs
@@ -3,6 +3,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
+use skyline::libc;
 use skyline::libc::c_void;
 use skyline::nn::{account, oe, time};
 
@@ -180,7 +181,7 @@ pub fn smash_version() -> String {
     unsafe {
         oe::GetDisplayVersion(&mut smash_version);
 
-        std::ffi::CStr::from_ptr(smash_version.name.as_ptr() as *const i8)
+        std::ffi::CStr::from_ptr(smash_version.name.as_ptr() as *const libc::c_char)
             .to_string_lossy()
             .into_owned()
     }


### PR DESCRIPTION
Previous error:

```
error[E0308]: mismatched types=======> ] 190/191: training_modpack                               
   --> src/common/events.rs:183:34
    |
183 |         std::ffi::CStr::from_ptr(smash_version.name.as_ptr() as *const i8)
    |         ------------------------ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `*const u8`, found `*const i8`
    |         |
    |         arguments to this function are incorrect
    |
    = note: expected raw pointer `*const u8`
               found raw pointer `*const i8`
note: associated function defined here
   --> /Users/austin/.cargo/skyline/toolchain/skyline/lib/rustlib/src/rust/library/core/src/ffi/c_str.rs:260:25
```

Using `ffi::c_char` directly fixes this compilation error.