### PR TITLE
Remove references to NN HID hook

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -109,10 +109,8 @@ jobs:
           cp plugin/libtraining_modpack.nro ${{env.SMASH_PLUGIN_DIR}}/libtraining_modpack.nro
           wget https://github.com/ultimate-research/params-hook-plugin/releases/download/v13.0.1/libparam_hook.nro
           wget https://github.com/ultimate-research/nro-hook-plugin/releases/download/v0.4.0/libnro_hook.nro
-          wget https://github.com/jugeeya/nn-hid-hook/releases/download/beta/libnn_hid_hook.nro
           cp libparam_hook.nro ${{env.SMASH_PLUGIN_DIR}}/libparam_hook.nro
           cp libnro_hook.nro ${{env.SMASH_PLUGIN_DIR}}/libnro_hook.nro
-          cp libnn_hid_hook.nro ${{env.SMASH_PLUGIN_DIR}}/libnn_hid_hook.nro
           zip -r training_modpack_beta.zip atmosphere
       - name: Delete Release
         uses: dev-drprasad/delete-tag-and-release@v0.2.1
@@ -176,7 +174,6 @@ jobs:
                         └── romfs/
                             └── skyline/
                                 └── plugins/
-                                    ├── libnn_hid_hook.nro
                                     ├── libnro_hook.nro
                                     ├── libparam_hook.nro
                                     └── libtraining_modpack.nro
@@ -207,7 +204,6 @@ jobs:
                           └── romfs/
                               └── skyline/
                                   └── plugins/
-                                      ├── libnn_hid_hook.nro
                                       ├── libnro_hook.nro
                                       ├── libparam_hook.nro
                                       └── libtraining_modpack.nro

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,8 +51,7 @@ lto = true
 titleid = "01006A800016E000"
 plugin-dependencies = [
     { name = "libnro_hook.nro", url = "https://github.com/ultimate-research/nro-hook-plugin/releases/download/v0.4.0/libnro_hook.nro" },
-    { name = "libparam_hook.nro", url = "https://github.com/ultimate-research/params-hook-plugin/releases/download/v0.1.1/libparam_hook.nro" },
-    { name = "libnn_hid_hook.nro", url = "https://github.com/jugeeya/nn-hid-hook/releases/download/beta/libnn_hid_hook.nro" }
+    { name = "libparam_hook.nro", url = "https://github.com/ultimate-research/params-hook-plugin/releases/download/v0.1.1/libparam_hook.nro" }
 ]
 
 [features]

--- a/README.md
+++ b/README.md
@@ -302,7 +302,6 @@ SD Card Root
             └── romfs/
                 └── skyline/
                     └── plugins/
-                        ├── libnn_hid_hook.nro
                         ├── libnro_hook.nro
                         ├── libparam_hook.nro
                         └── libtraining_modpack.nro
@@ -328,7 +327,6 @@ Exact same process as above, but the filepaths are in Ryujinx's mod paths.
               └── romfs/
                   └── skyline/
                       └── plugins/
-                          ├── libnn_hid_hook.nro
                           ├── libnro_hook.nro
                           ├── libparam_hook.nro
                           └── libtraining_modpack.nro
@@ -396,7 +394,6 @@ To install a beta version of the modpack, follow the same procedure using the [l
 
     Removing the Training Modpack is as simple as deleting the files and folders that are associated with the modpack, listed below:
     `SD:/atmosphere/contents/01006A800016E000/manual_html/html-document/training_modpack.htdocs/`
-    `SD:/atmosphere/contents/01006A800016E000/romfs/skyline/plugins/libnn_hid_hook.nro`
     `SD:/atmosphere/contents/01006A800016E000/romfs/skyline/plugins/libnro_hook.nro`
     `SD:/atmosphere/contents/01006A800016E000/romfs/skyline/plugins/libparam_hook.nro`
     `SD:/atmosphere/contents/01006A800016E000/romfs/skyline/plugins/libtraining_modpack.nro`


### PR DESCRIPTION
- NN HID hook is now unused due to using native Smash structs