### PR TITLE
Open Menu with Start Press

### DIFF
--- a/ryujinx_build.ps1
+++ b/ryujinx_build.ps1
@@ -7,7 +7,7 @@ $LOCAL_LAYOUT_ARC_PATH="C:\Users\Josh\Documents\Games\UltimateTrainingModpack\sr
 $RYUJINX_PLUGIN_PATH="C:\Users\Josh\AppData\Roaming\Ryujinx\mods\contents\01006a800016e000\romfs\skyline\plugins\libtraining_modpack.nro"
 $LOCAL_PLUGIN_PATH="C:\Users\Josh\Documents\Games\UltimateTrainingModpack\target\aarch64-skyline-switch\release\libtraining_modpack.nro"
 
-$RYUJINX_EXE_PATH="C:\Users\Josh\Documents\Games\Ryujinx\publish\Ryujinx.exe"
+$RYUJINX_EXE_PATH="C:\Users\Josh\Documents\Games\Ryujinx\ryujinx-1.1.999-win_x64\publish\Ryujinx.exe"
 $SMASH_NSP_PATH='C:\Users\Josh\Documents\Games\ROMs\Super Smash Bros Ultimate [Base Game]\Super Smash Bros Ultimate[01006A800016E000][US][v0].nsp'
 
 

--- a/src/common/button_config.rs
+++ b/src/common/button_config.rs
@@ -59,10 +59,12 @@ pub enum ButtonCombo {
     InputPlayback,
 }
 
+pub const DEFAULT_OPEN_MENU_CONFIG: ButtonConfig = ButtonConfig::B.union(ButtonConfig::DPAD_UP);
+
 unsafe fn get_combo_keys(combo: ButtonCombo) -> ButtonConfig {
     match combo {
         // For OpenMenu, have a default in addition to accepting start press
-        ButtonCombo::OpenMenu => ButtonConfig::B.union(ButtonConfig::DPAD_UP),
+        ButtonCombo::OpenMenu => DEFAULT_OPEN_MENU_CONFIG,
         ButtonCombo::SaveState => MENU.save_state_save,
         ButtonCombo::LoadState => MENU.save_state_load,
         ButtonCombo::InputRecord => MENU.input_record,

--- a/src/common/button_config.rs
+++ b/src/common/button_config.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use crate::common::*;
 use crate::input::{ControllerStyle::*, *};
+use crate::training::frame_counter;
 use crate::training::ui::menu::VANILLA_MENU_ACTIVE;
 
 use lazy_static::lazy_static;
@@ -134,6 +135,8 @@ pub fn handle_final_input_mapping(player_idx: i32, controller_struct: &mut SomeC
         let p1_controller = &mut *controller_struct.controller;
         let mut start_menu_request = false;
 
+        let menu_close_wait_frame =
+            unsafe { frame_counter::get_frame_count(menu::FRAME_COUNTER_INDEX) };
         if unsafe { MENU.menu_open_start_press == OnOff::On } {
             let start_hold_frames = &mut *START_HOLD_FRAMES.lock();
             if p1_controller.current_buttons.plus() {
@@ -143,9 +146,12 @@ pub fn handle_final_input_mapping(player_idx: i32, controller_struct: &mut SomeC
                 p1_controller.just_down.set_plus(false);
                 p1_controller.just_release.set_plus(false);
             } else {
-                if *start_hold_frames > 0 {
+                if *start_hold_frames > 0 && menu_close_wait_frame == 0 {
                     // Here, we just finished holding start
-                    if *start_hold_frames < 10 && unsafe { !VANILLA_MENU_ACTIVE } {
+                    if *start_hold_frames < 10
+                        && unsafe { !VANILLA_MENU_ACTIVE }
+                        && menu_close_wait_frame == 0
+                    {
                         // If we held for fewer than 10 frames, let's open the training mod menu
                         start_menu_request = true;
                     } else if unsafe { !QUICK_MENU_ACTIVE } {

--- a/src/common/button_config.rs
+++ b/src/common/button_config.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use crate::common::*;
 use crate::input::{ControllerStyle::*, *};
+use crate::training::ui::menu::VANILLA_MENU_ACTIVE;
 
 use lazy_static::lazy_static;
 use parking_lot::Mutex;
@@ -143,7 +144,7 @@ pub fn handle_final_input_mapping(player_idx: i32, controller_struct: &mut SomeC
         } else {
             if *start_hold_frames > 0 {
                 // Here, we just finished holding start
-                if *start_hold_frames < 10 {
+                if *start_hold_frames < 10 && unsafe { !VANILLA_MENU_ACTIVE } {
                     // If we held for fewer than 10 frames, let's open the training mod menu
                     start_menu_request = true;
                 } else if unsafe { !QUICK_MENU_ACTIVE } {
@@ -151,6 +152,9 @@ pub fn handle_final_input_mapping(player_idx: i32, controller_struct: &mut SomeC
                     // So long as our menu isn't active
                     p1_controller.current_buttons.set_plus(true);
                     p1_controller.just_down.set_plus(true);
+                    unsafe {
+                        VANILLA_MENU_ACTIVE = true;
+                    }
                 }
             }
             *start_hold_frames = 0;

--- a/src/common/input.rs
+++ b/src/common/input.rs
@@ -267,7 +267,7 @@ pub struct SomeControllerStruct {
 }
 
 // Define struct used for final controller inputs
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 #[repr(C)]
 pub struct MappedInputs {
     pub buttons: Buttons,

--- a/src/common/menu.rs
+++ b/src/common/menu.rs
@@ -17,7 +17,6 @@ use crate::logging::*;
 // This is a special frame counter that will tick on draw()
 // We'll count how long the menu has been open
 pub static mut FRAME_COUNTER: u32 = 0;
-const MENU_CLOSE_WAIT_FRAMES: u32 = 60;
 pub static mut QUICK_MENU_ACTIVE: bool = false;
 
 pub unsafe fn menu_condition() -> bool {
@@ -72,23 +71,18 @@ pub unsafe fn set_menu_from_json(message: &str) {
 
 pub fn spawn_menu() {
     unsafe {
-        FRAME_COUNTER = 0;
         QUICK_MENU_ACTIVE = true;
     }
 }
 
 #[derive(Eq, PartialEq, Hash, Copy, Clone)]
 enum DirectionButton {
-    DpadLeft,
     LLeft,
     RLeft,
-    DpadDown,
     LDown,
     RDown,
-    DpadRight,
     LRight,
     RRight,
-    DpadUp,
     LUp,
     RUp,
 }
@@ -107,16 +101,12 @@ lazy_static! {
     static ref DIRECTION_HOLD_FRAMES: Mutex<HashMap<DirectionButton, u32>> = {
         use DirectionButton::*;
         Mutex::new(HashMap::from([
-            (DpadLeft, 0),
             (LLeft, 0),
             (RLeft, 0),
-            (DpadDown, 0),
             (LDown, 0),
             (RDown, 0),
-            (DpadRight, 0),
             (LRight, 0),
             (RRight, 0),
-            (DpadUp, 0),
             (LUp, 0),
             (RUp, 0),
         ]))
@@ -161,16 +151,12 @@ pub fn handle_final_input_mapping(
                     .iter_mut()
                     .for_each(|(direction, frames)| {
                         let still_held = match direction {
-                            DpadLeft => button_current_held.dpad_left(),
                             LLeft => button_current_held.l_left(),
                             RLeft => button_current_held.r_left(),
-                            DpadDown => button_current_held.dpad_down(),
                             LDown => button_current_held.l_down(),
                             RDown => button_current_held.r_down(),
-                            DpadRight => button_current_held.dpad_right(),
                             LRight => button_current_held.l_right(),
                             RRight => button_current_held.r_right(),
-                            DpadUp => button_current_held.dpad_up(),
                             LUp => button_current_held.l_up(),
                             RUp => button_current_held.r_up(),
                         };
@@ -190,10 +176,9 @@ pub fn handle_final_input_mapping(
                     received_input = true;
                     if app.page != AppPage::SUBMENU {
                         app.on_b()
-                    } else if FRAME_COUNTER > MENU_CLOSE_WAIT_FRAMES {
+                    } else {
                         // Leave menu.
                         QUICK_MENU_ACTIVE = false;
-                        FRAME_COUNTER = 0;
                         let menu_json = app.get_menu_selections();
                         set_menu_from_json(&menu_json);
                         EVENT_QUEUE.push(Event::menu_open(menu_json));
@@ -227,7 +212,7 @@ pub fn handle_final_input_mapping(
                 (button_presses.dpad_left()
                     || button_presses.l_left()
                     || button_presses.r_left()
-                    || [DpadLeft, LLeft, RLeft].iter().any(hold_condition))
+                    || [LLeft, RLeft].iter().any(hold_condition))
                 .then(|| {
                     received_input = true;
                     app.on_left();
@@ -235,7 +220,7 @@ pub fn handle_final_input_mapping(
                 (button_presses.dpad_right()
                     || button_presses.l_right()
                     || button_presses.r_right()
-                    || [DpadRight, LRight, RRight].iter().any(hold_condition))
+                    || [LRight, RRight].iter().any(hold_condition))
                 .then(|| {
                     received_input = true;
                     app.on_right();
@@ -243,7 +228,7 @@ pub fn handle_final_input_mapping(
                 (button_presses.dpad_up()
                     || button_presses.l_up()
                     || button_presses.r_up()
-                    || [DpadUp, LUp, RUp].iter().any(hold_condition))
+                    || [LUp, RUp].iter().any(hold_condition))
                 .then(|| {
                     received_input = true;
                     app.on_up();
@@ -251,7 +236,7 @@ pub fn handle_final_input_mapping(
                 (button_presses.dpad_down()
                     || button_presses.l_down()
                     || button_presses.r_down()
-                    || [DpadDown, LDown, RDown].iter().any(hold_condition))
+                    || [LDown, RDown].iter().any(hold_condition))
                 .then(|| {
                     received_input = true;
                     app.on_down();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,7 +106,7 @@ pub fn main() {
 
     unsafe {
         notification("Training Modpack".to_string(), "Welcome!".to_string(), 60);
-        notification("Open Menu".to_string(), MENU.menu_open.to_string(), 120);
+        notification("Open Menu".to_string(), "Start".to_string(), 120);
         notification(
             "Save State".to_string(),
             MENU.save_state_save.to_string(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,8 +18,9 @@ use std::fs;
 use std::path::PathBuf;
 
 use skyline::nro::{self, NroInfo};
-use training_mod_consts::LEGACY_TRAINING_MODPACK_ROOT;
+use training_mod_consts::{OnOff, LEGACY_TRAINING_MODPACK_ROOT};
 
+use crate::common::button_config::DEFAULT_OPEN_MENU_CONFIG;
 use crate::common::events::events_loop;
 use crate::common::*;
 use crate::consts::TRAINING_MODPACK_ROOT;
@@ -117,7 +118,15 @@ pub fn main() {
 
     unsafe {
         notification("Training Modpack".to_string(), "Welcome!".to_string(), 60);
-        notification("Open Menu".to_string(), "Start".to_string(), 120);
+        notification(
+            "Open Menu".to_string(),
+            if MENU.menu_open_start_press == OnOff::On {
+                "Start".to_string()
+            } else {
+                DEFAULT_OPEN_MENU_CONFIG.to_string()
+            },
+            120,
+        );
         notification(
             "Save State".to_string(),
             MENU.save_state_save.to_string(),

--- a/src/training/frame_counter.rs
+++ b/src/training/frame_counter.rs
@@ -1,15 +1,25 @@
 static mut SHOULD_COUNT: Vec<bool> = vec![];
+static mut NO_RESET: Vec<bool> = vec![];
 static mut COUNTERS: Vec<u32> = vec![];
 
-pub fn register_counter() -> usize {
+fn _register_counter(no_reset: bool) -> usize {
     unsafe {
         let index = COUNTERS.len();
 
         COUNTERS.push(0);
         SHOULD_COUNT.push(false);
+        NO_RESET.push(no_reset);
 
         index
     }
+}
+
+pub fn register_counter_no_reset() -> usize {
+    _register_counter(true)
+}
+
+pub fn register_counter() -> usize {
+    _register_counter(false)
 }
 
 pub fn start_counting(index: usize) {
@@ -81,6 +91,9 @@ pub fn tick() {
 pub fn reset_all() {
     unsafe {
         for (index, _frame) in COUNTERS.iter().enumerate() {
+            if NO_RESET[index] {
+                continue;
+            }
             full_reset(index);
         }
     }

--- a/src/training/mod.rs
+++ b/src/training/mod.rs
@@ -701,8 +701,8 @@ unsafe fn handle_final_input_mapping(
     if !is_training_mode() {
         return;
     }
-    button_config::handle_final_input_mapping(player_idx, controller_struct);
     menu::handle_final_input_mapping(player_idx, controller_struct, out);
+    button_config::handle_final_input_mapping(player_idx, controller_struct);
     dev_config::handle_final_input_mapping(player_idx, controller_struct);
     input_delay::handle_final_input_mapping(player_idx, out);
     input_record::handle_final_input_mapping(player_idx, out);

--- a/src/training/mod.rs
+++ b/src/training/mod.rs
@@ -800,4 +800,5 @@ pub fn training_mods() {
     tech::init();
     input_record::init();
     ui::init();
+    menu::init();
 }

--- a/src/training/ui/menu.rs
+++ b/src/training/ui/menu.rs
@@ -53,6 +53,8 @@ const BG_LEFT_SELECTED_WHITE_COLOR: ResColor = ResColor {
     a: 255,
 };
 
+pub static mut VANILLA_MENU_ACTIVE: bool = false;
+
 lazy_static! {
     static ref GCC_BUTTON_MAPPING: HashMap<&'static str, u16> = HashMap::from([
         ("L", 0xE204),
@@ -346,6 +348,15 @@ unsafe fn render_slider_page(app: &App, root_pane: &Pane) {
 }
 
 pub unsafe fn draw(root_pane: &Pane) {
+    // Determine if we're in the menu by seeing if the "help" footer has
+    // begun moving upward. It starts at -80 and moves to 0 over 10 frames
+    // in info_training_in_menu.bflan
+    VANILLA_MENU_ACTIVE = root_pane
+        .find_pane_by_name_recursive("L_staying_help")
+        .unwrap()
+        .pos_y
+        != -80.0;
+
     // Update menu display
     // Grabbing lock as read-only, essentially
     let app = &*crate::common::menu::QUICK_MENU_APP.data_ptr();

--- a/src/training/ui/menu.rs
+++ b/src/training/ui/menu.rs
@@ -6,7 +6,11 @@ use smash::ui2d::{SmashPane, SmashTextBox};
 use training_mod_tui::gauge::GaugeState;
 use training_mod_tui::{App, AppPage, NUM_LISTS};
 
+use crate::common::menu::{self, MENU_CLOSE_WAIT_FRAMES};
+use crate::training::frame_counter;
 use crate::{common, common::menu::QUICK_MENU_ACTIVE, input::*};
+
+use super::fade_out;
 
 pub static NUM_MENU_TEXT_OPTIONS: usize = 32;
 pub static _NUM_MENU_TABS: usize = 3;
@@ -368,10 +372,22 @@ pub unsafe fn draw(root_pane: &Pane) {
         }
     }
 
-    root_pane
-        .find_pane_by_name_recursive("TrModMenu")
-        .unwrap()
-        .set_visible(QUICK_MENU_ACTIVE);
+    let overall_parent_pane = root_pane.find_pane_by_name_recursive("TrModMenu").unwrap();
+    overall_parent_pane.set_visible(true);
+    let menu_close_wait_frame = frame_counter::get_frame_count(menu::FRAME_COUNTER_INDEX);
+    if QUICK_MENU_ACTIVE {
+        overall_parent_pane.alpha = 255;
+        overall_parent_pane.global_alpha = 255;
+    } else if menu_close_wait_frame > 0 {
+        fade_out(
+            overall_parent_pane,
+            30 - menu_close_wait_frame,
+            MENU_CLOSE_WAIT_FRAMES,
+        );
+    } else {
+        overall_parent_pane.alpha = 0;
+        overall_parent_pane.global_alpha = 0;
+    }
 
     // Make all invisible first
     (0..NUM_MENU_TEXT_OPTIONS).for_each(|idx| {

--- a/src/training/ui/menu.rs
+++ b/src/training/ui/menu.rs
@@ -372,9 +372,6 @@ pub unsafe fn draw(root_pane: &Pane) {
         .find_pane_by_name_recursive("TrModMenu")
         .unwrap()
         .set_visible(QUICK_MENU_ACTIVE);
-    if QUICK_MENU_ACTIVE {
-        common::menu::FRAME_COUNTER += 1;
-    }
 
     // Make all invisible first
     (0..NUM_MENU_TEXT_OPTIONS).for_each(|idx| {

--- a/src/training/ui/menu.rs
+++ b/src/training/ui/menu.rs
@@ -381,7 +381,7 @@ pub unsafe fn draw(root_pane: &Pane) {
     } else if menu_close_wait_frame > 0 {
         fade_out(
             overall_parent_pane,
-            30 - menu_close_wait_frame,
+            MENU_CLOSE_WAIT_FRAMES - menu_close_wait_frame,
             MENU_CLOSE_WAIT_FRAMES,
         );
     } else {

--- a/src/training/ui/mod.rs
+++ b/src/training/ui/mod.rs
@@ -16,15 +16,15 @@ pub mod notifications;
 pub fn fade_out(pane: &mut Pane, current_frame: u32, total_frames: u32) {
     if current_frame < total_frames {
         // Logarithmic fade out
-        // let alpha = ((255.0 / (total_frames as f32 + 1.0).log10())
-        //     * (current_frame as f32 + 1.0).log10()) as u8;
-        // pane.alpha = alpha;
-        // pane.global_alpha = alpha;
-
-        // Linear fade out
-        let alpha = ((current_frame as f32 / 100.0) * 255.0) as u8;
+        let alpha = ((255.0 / (total_frames as f32 + 1.0).log10())
+            * (current_frame as f32 + 1.0).log10()) as u8;
         pane.alpha = alpha;
         pane.global_alpha = alpha;
+
+        // Linear fade out
+        // let alpha = ((current_frame as f32 / 100.0) * 255.0) as u8;
+        // pane.alpha = alpha;
+        // pane.global_alpha = alpha;
     } else {
         pane.alpha = 0;
         pane.global_alpha = 0;

--- a/src/training/ui/mod.rs
+++ b/src/training/ui/mod.rs
@@ -13,6 +13,24 @@ mod display;
 pub mod menu;
 pub mod notifications;
 
+pub fn fade_out(pane: &mut Pane, current_frame: u32, total_frames: u32) {
+    if current_frame < total_frames {
+        // Logarithmic fade out
+        // let alpha = ((255.0 / (total_frames as f32 + 1.0).log10())
+        //     * (current_frame as f32 + 1.0).log10()) as u8;
+        // pane.alpha = alpha;
+        // pane.global_alpha = alpha;
+
+        // Linear fade out
+        let alpha = ((current_frame as f32 / 100.0) * 255.0) as u8;
+        pane.alpha = alpha;
+        pane.global_alpha = alpha;
+    } else {
+        pane.alpha = 0;
+        pane.global_alpha = 0;
+    }
+}
+
 #[skyline::hook(offset = 0x4b620)]
 pub unsafe fn handle_draw(layout: *mut Layout, draw_info: u64, cmd_buffer: u64) {
     let layout_name = skyline::from_c_str((*layout).layout_name);

--- a/src/training/ui/mod.rs
+++ b/src/training/ui/mod.rs
@@ -10,7 +10,7 @@ use crate::consts::LAYOUT_ARC_PATH;
 
 mod damage;
 mod display;
-mod menu;
+pub mod menu;
 pub mod notifications;
 
 #[skyline::hook(offset = 0x4b620)]

--- a/training_mod_consts/src/lib.rs
+++ b/training_mod_consts/src/lib.rs
@@ -139,7 +139,7 @@ pub static DEFAULTS_MENU: TrainingModpackMenu = TrainingModpackMenu {
     follow_up: Action::empty(),
     frame_advantage: OnOff::Off,
     full_hop: BoolFlag::TRUE,
-    hitbox_vis: OnOff::On,
+    hitbox_vis: OnOff::Off,
     hud: OnOff::On,
     input_delay: Delay::D0,
     ledge_delay: LongDelay::empty(),

--- a/training_mod_consts/src/lib.rs
+++ b/training_mod_consts/src/lib.rs
@@ -83,6 +83,7 @@ pub struct TrainingModpackMenu {
     pub hitstun_playback: HitstunPlayback,
     pub playback_mash: OnOff,
     pub playback_loop: OnOff,
+    pub menu_open_start_press: OnOff,
     pub save_state_save: ButtonConfig,
     pub save_state_load: ButtonConfig,
     pub input_record: ButtonConfig,
@@ -187,6 +188,7 @@ pub static DEFAULTS_MENU: TrainingModpackMenu = TrainingModpackMenu {
     hitstun_playback: HitstunPlayback::Hitstun,
     playback_mash: OnOff::On,
     playback_loop: OnOff::Off,
+    menu_open_start_press: OnOff::On,
     save_state_save: ButtonConfig::ZL.union(ButtonConfig::DPAD_DOWN),
     save_state_load: ButtonConfig::ZL.union(ButtonConfig::DPAD_UP),
     input_record: ButtonConfig::ZR.union(ButtonConfig::DPAD_DOWN),
@@ -854,6 +856,13 @@ pub unsafe fn ui_menu(menu: TrainingModpackMenu) -> UiMenu {
         tab_title: "Button Config".to_string(),
         tab_submenus: Vec::new(),
     };
+    button_tab.add_submenu_with_toggles::<OnOff>(
+        "Menu Open Start Press".to_string(),
+        "menu_open_start_press".to_string(),
+        "Menu Open Start Press: Press start to open the mod menu. To open the original menu, hold start.\nThe default menu open option is always available as Hold B + Press DPad Up.".to_string(),
+        true,
+        &(menu.menu_open_start_press as u32),
+    );
     button_tab.add_submenu_with_toggles::<ButtonConfig>(
         "Save State Save".to_string(),
         "save_state_save".to_string(),
@@ -861,7 +870,6 @@ pub unsafe fn ui_menu(menu: TrainingModpackMenu) -> UiMenu {
         false,
         &(menu.save_state_save.bits() as u32),
     );
-
     button_tab.add_submenu_with_toggles::<ButtonConfig>(
         "Save State Load".to_string(),
         "save_state_load".to_string(),

--- a/training_mod_consts/src/lib.rs
+++ b/training_mod_consts/src/lib.rs
@@ -339,6 +339,48 @@ pub struct UiMenu {
 pub unsafe fn ui_menu(menu: TrainingModpackMenu) -> UiMenu {
     let mut overall_menu = UiMenu { tabs: Vec::new() };
 
+    let mut button_tab = Tab {
+        tab_id: "button".to_string(),
+        tab_title: "Button Config".to_string(),
+        tab_submenus: Vec::new(),
+    };
+    button_tab.add_submenu_with_toggles::<OnOff>(
+        "Menu Open Start Press".to_string(),
+        "menu_open_start_press".to_string(),
+        "Menu Open Start Press: Press start to open the mod menu. To open the original menu, hold start.\nThe default menu open option is always available as Hold B + Press DPad Up.".to_string(),
+        true,
+        &(menu.menu_open_start_press as u32),
+    );
+    button_tab.add_submenu_with_toggles::<ButtonConfig>(
+        "Save State Save".to_string(),
+        "save_state_save".to_string(),
+        "Save State Save: Hold any one button and press the others to trigger".to_string(),
+        false,
+        &(menu.save_state_save.bits() as u32),
+    );
+    button_tab.add_submenu_with_toggles::<ButtonConfig>(
+        "Save State Load".to_string(),
+        "save_state_load".to_string(),
+        "Save State Load: Hold any one button and press the others to trigger".to_string(),
+        false,
+        &(menu.save_state_load.bits() as u32),
+    );
+    button_tab.add_submenu_with_toggles::<ButtonConfig>(
+        "Input Record".to_string(),
+        "input_record".to_string(),
+        "Input Record: Hold any one button and press the others to trigger".to_string(),
+        false,
+        &(menu.input_record.bits() as u32),
+    );
+    button_tab.add_submenu_with_toggles::<ButtonConfig>(
+        "Input Playback".to_string(),
+        "input_playback".to_string(),
+        "Input Playback: Hold any one button and press the others to trigger".to_string(),
+        false,
+        &(menu.input_playback.bits() as u32),
+    );
+    overall_menu.tabs.push(button_tab);
+
     let mut mash_tab = Tab {
         tab_id: "mash".to_string(),
         tab_title: "Mash Settings".to_string(),
@@ -850,48 +892,6 @@ pub unsafe fn ui_menu(menu: TrainingModpackMenu) -> UiMenu {
         &(menu.recording_crop as u32),
     );
     overall_menu.tabs.push(input_tab);
-
-    let mut button_tab = Tab {
-        tab_id: "button".to_string(),
-        tab_title: "Button Config".to_string(),
-        tab_submenus: Vec::new(),
-    };
-    button_tab.add_submenu_with_toggles::<OnOff>(
-        "Menu Open Start Press".to_string(),
-        "menu_open_start_press".to_string(),
-        "Menu Open Start Press: Press start to open the mod menu. To open the original menu, hold start.\nThe default menu open option is always available as Hold B + Press DPad Up.".to_string(),
-        true,
-        &(menu.menu_open_start_press as u32),
-    );
-    button_tab.add_submenu_with_toggles::<ButtonConfig>(
-        "Save State Save".to_string(),
-        "save_state_save".to_string(),
-        "Save State Save: Hold any one button and press the others to trigger".to_string(),
-        false,
-        &(menu.save_state_save.bits() as u32),
-    );
-    button_tab.add_submenu_with_toggles::<ButtonConfig>(
-        "Save State Load".to_string(),
-        "save_state_load".to_string(),
-        "Save State Load: Hold any one button and press the others to trigger".to_string(),
-        false,
-        &(menu.save_state_load.bits() as u32),
-    );
-    button_tab.add_submenu_with_toggles::<ButtonConfig>(
-        "Input Record".to_string(),
-        "input_record".to_string(),
-        "Input Record: Hold any one button and press the others to trigger".to_string(),
-        false,
-        &(menu.input_record.bits() as u32),
-    );
-    button_tab.add_submenu_with_toggles::<ButtonConfig>(
-        "Input Playback".to_string(),
-        "input_playback".to_string(),
-        "Input Playback: Hold any one button and press the others to trigger".to_string(),
-        false,
-        &(menu.input_playback.bits() as u32),
-    );
-    overall_menu.tabs.push(button_tab);
 
     overall_menu
 }

--- a/training_mod_consts/src/lib.rs
+++ b/training_mod_consts/src/lib.rs
@@ -81,7 +81,6 @@ pub struct TrainingModpackMenu {
     pub hitstun_playback: HitstunPlayback,
     pub playback_mash: OnOff,
     pub playback_loop: OnOff,
-    pub menu_open: ButtonConfig,
     pub save_state_save: ButtonConfig,
     pub save_state_load: ButtonConfig,
     pub input_record: ButtonConfig,
@@ -185,7 +184,6 @@ pub static DEFAULTS_MENU: TrainingModpackMenu = TrainingModpackMenu {
     hitstun_playback: HitstunPlayback::Hitstun,
     playback_mash: OnOff::On,
     playback_loop: OnOff::Off,
-    menu_open: ButtonConfig::B.union(ButtonConfig::DPAD_UP),
     save_state_save: ButtonConfig::ZL.union(ButtonConfig::DPAD_DOWN),
     save_state_load: ButtonConfig::ZL.union(ButtonConfig::DPAD_UP),
     input_record: ButtonConfig::ZR.union(ButtonConfig::DPAD_DOWN),
@@ -844,13 +842,6 @@ pub unsafe fn ui_menu(menu: TrainingModpackMenu) -> UiMenu {
         tab_title: "Button Config".to_string(),
         tab_submenus: Vec::new(),
     };
-    button_tab.add_submenu_with_toggles::<ButtonConfig>(
-        "Menu Open".to_string(),
-        "menu_open".to_string(),
-        "Menu Open: Hold: Hold any one button and press the others to trigger".to_string(),
-        false,
-        &(menu.menu_open.bits() as u32),
-    );
     button_tab.add_submenu_with_toggles::<ButtonConfig>(
         "Save State Save".to_string(),
         "save_state_save".to_string(),

--- a/training_mod_tui/src/main.rs
+++ b/training_mod_tui/src/main.rs
@@ -222,6 +222,8 @@ fn test_toggle_naming() -> Result<(), Box<dyn Error>> {
     }
 
     let (mut terminal, mut app) = test_backend_setup(menu, menu_defaults)?;
+    // Enter Mash Section
+    app.next_tab();
     // Enter Mash Toggles
     app.on_a();
     // Set Mash Airdodge

--- a/training_mod_tui/src/main.rs
+++ b/training_mod_tui/src/main.rs
@@ -48,6 +48,8 @@ fn test_set_airdodge() -> Result<(), Box<dyn Error>> {
     }
 
     let (_terminal, mut app) = test_backend_setup(menu, menu_defaults)?;
+    // Enter Mash Section
+    app.next_tab();
     // Enter Mash Toggles
     app.on_a();
     // Set Mash Airdodge
@@ -103,6 +105,8 @@ fn test_save_and_reset_defaults() -> Result<(), Box<dyn Error>> {
 
     let (_terminal, mut app) = test_backend_setup(menu, menu_defaults)?;
 
+    // Enter Mash Section
+    app.next_tab();
     // Enter Mash Toggles
     app.on_a();
     // Set Mash Airdodge
@@ -146,6 +150,8 @@ fn test_save_and_reset_defaults() -> Result<(), Box<dyn Error>> {
         "The menu should have Mash Airdodge"
     );
 
+    // Enter Mash Section
+    app.next_tab();
     // Enter Mash Toggles
     app.on_a();
     // Unset Mash Airdodge


### PR DESCRIPTION
- Add a default on toggle in order to allow users to open the menu with start press.
  - Start Press for < 10 frames gives the training mod menu
  - Start Hold for >= 10 frames gives the vanilla menu
- Menu Open is now either start press via the toggle above, or default B+DPad Up will always work.
- The menu opens to the button config with a long help text that explains the behavior above
- Allow users to close the menu immediately after opening it
- Closing the menu can now be done with either B or Start, and Start can close the menu even from within a submenu
- There is now a 15 frame wait after closing the menu such that inputs for closing the menu do not affect in-game (B causing a Special input, Start reopening the menu or opening the vanilla menu)
- Turn off hitbox visualization by default since the above is enough to show the user they have the mod working