### PR TITLE
Robustify Powershell script, add instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,6 +465,24 @@ To build the entire modpack including supporting files, use the steps in the [Gi
 ## Prerequisites
 - Stable Rust environment with [cargo-skyline](https://github.com/jam1garner/cargo-skyline)
 
+## Development Tips
+
+### Ryujinx
+
+Developing on Ryujinx on Windows is very easy and has a streamlined script in [ryujinx_build.ps1](./ryujinx_build.ps1).
+
+1. Drag-and-drop the normal beta at the Ryujinx paths as described in Installation.
+2. Delete the `libtraining_modpack.nro` that is used in those paths.
+3. Edit the paths at the top of the file to match your local filesystem
+4. On your first run, you may have to run the script as Administrator in order to set up the symlinks to this repo's built files.
+    - Both the plugin and the [layout.arc](./src/static/layout.arc) will be sourced automatically via symlink
+5. Run the script to iterate and develop.
+    - Logs will be printed to console. 
+    - Since we are using the feature `layout-arc-from-file`, you can edit [layout.arc](./src/static/layout.arc) in real-time with Switch Toolbox and reload training mode without rebooting to view your changes.
+    - If you'd like to exit, you can CTRL+C the script and Ryujinx will also close.
+
+
+
 <a name="beta-changelog"/>
 
 # Beta Changelog

--- a/ryujinx_build.ps1
+++ b/ryujinx_build.ps1
@@ -1,21 +1,54 @@
-$IP=(Test-Connection -ComputerName (hostname) -Count 1  | Select -ExpandProperty IPV4Address).IPAddressToString
-cargo skyline build --release --features layout_arc_from_file
-
-# Set up symlinks
+# Change these to match your local
+# The first time you run this, in order to set up the symlinks, you may have to be an administrator
+# to write the files. Powershell is dumb.
 $RYUJINX_LAYOUT_ARC_PATH="C:\Users\Josh\AppData\Roaming\Ryujinx\sdcard\ultimate\TrainingModpack\layout.arc"
 $LOCAL_LAYOUT_ARC_PATH="C:\Users\Josh\Documents\Games\UltimateTrainingModpack\src\static\layout.arc"
-if(-not(Test-path $RYUJINX_LAYOUT_ARC_PATH -PathType leaf))
-{
-    New-Item -ItemType SymbolicLink -Path $RYUJINX_LAYOUT_ARC_PATH -Target $LOCAL_LAYOUT_ARC_PATH
-}
 
 $RYUJINX_PLUGIN_PATH="C:\Users\Josh\AppData\Roaming\Ryujinx\mods\contents\01006a800016e000\romfs\skyline\plugins\libtraining_modpack.nro"
 $LOCAL_PLUGIN_PATH="C:\Users\Josh\Documents\Games\UltimateTrainingModpack\target\aarch64-skyline-switch\release\libtraining_modpack.nro"
+
+$RYUJINX_EXE_PATH="C:\Users\Josh\Documents\Games\Ryujinx\publish\Ryujinx.exe"
+$SMASH_NSP_PATH='C:\Users\Josh\Documents\Games\ROMs\Super Smash Bros Ultimate [Base Game]\Super Smash Bros Ultimate[01006A800016E000][US][v0].nsp'
+
+
+$IP=(Test-Connection -ComputerName (hostname) -Count 1  | Select -ExpandProperty IPV4Address).IPAddressToString
+cargo skyline build --release --features layout_arc_from_file
+if (($lastexitcode -ne 0)) {
+    exit $lastexitcode
+}
+
+# Set up symlinks
+if(-not(Test-path $RYUJINX_LAYOUT_ARC_PATH -PathType leaf))
+{
+    New-Item -ItemType SymbolicLink -Path $RYUJINX_LAYOUT_ARC_PATH -Target $LOCAL_LAYOUT_ARC_PATH
+    if (($lastexitcode -ne 0)) {
+        exit $lastexitcode
+    }
+}
+
 if(-not(Test-path $RYUJINX_PLUGIN_PATH -PathType leaf))
 {
     New-Item -ItemType SymbolicLink -Path $RYUJINX_PLUGIN_PATH -Target $LOCAL_PLUGIN_PATH
+    if (($lastexitcode -ne 0)) {
+       exit $lastexitcode
+    }
 }
 
-C:\Users\Josh\Documents\Games\Ryujinx\publish\Ryujinx.exe "C:\Users\Josh\Documents\Games\ROMs\Super Smash Bros Ultimate [Base Game]\Super Smash Bros Ultimate[01006A800016E000][US][v0].nsp"
-cargo skyline listen --ip=$IP
-# C:\Users\Jdsam\Documents\Games\Emulators\ryujinx-1.1.299-win_x64\publish\BLAH.exe C:\Users\Jdsam\Documents\Games\Emulators\ryujinx-1.1.299-win_x64\publish\Ryujinx.exe "C:\Users\Jdsam\Documents\Games\SmashRoms\UltimateXCI\ultimate.xci"
+try {
+    # Start the process asynchronously
+    $process = Start-Process -FilePath $RYUJINX_EXE_PATH -ArgumentList `"$SMASH_NSP_PATH`" -PassThru
+
+    # Store the process ID
+    $global:process = $process.Id
+
+    echo "Starting cargo skyline listen..."
+    cargo skyline listen --ip=$IP
+    # Makes no sense, but we need this line for logs to show up. Lol
+    echo "Finishing cargo skyline listen..."
+}
+finally {
+    # Interrupts to the script should kill Ryujinx as well
+    if ($global:process -ne $null) {
+        Stop-Process -Id $global:process -Force
+    }
+}


### PR DESCRIPTION
- Fix up script to start Ryujinx, ignore its logs, use cargo-skyline logs, and have the ability to CTRL+C the script to stop Ryujinx and stop logs to iterate again
- Add instructions to the README