### PR TITLE
Add debug symbols into plugin NRO

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -60,7 +60,7 @@ jobs:
           cargo-skyline skyline update-std
       - name: Build release NRO
         id: build_release
-        run: cargo-skyline skyline build --release
+        run: RUSTFLAGS=-g cargo-skyline skyline build --release
       - name: Upload plugin artifact
         uses: actions/upload-artifact@v3
         with:
@@ -85,7 +85,7 @@ jobs:
           cargo install cargo-skyline
           cargo-skyline skyline update-std
       - name: Build outside_training_mode NRO
-        run: cargo-skyline skyline build --release --features outside_training_mode
+        run: RUSTFLAGS=-g cargo-skyline skyline build --release --features outside_training_mode
       - name: Upload plugin (outside training mode) artifact
         uses: actions/upload-artifact@v3
         with:

--- a/ryujinx_build.ps1
+++ b/ryujinx_build.ps1
@@ -12,6 +12,9 @@ $SMASH_NSP_PATH='C:\Users\Josh\Documents\Games\ROMs\Super Smash Bros Ultimate [B
 
 
 $IP=(Test-Connection -ComputerName (hostname) -Count 1  | Select -ExpandProperty IPV4Address).IPAddressToString
+
+# Set symbols flag
+$env:RUSTFLAGS="-g"
 cargo skyline build --release --features layout_arc_from_file
 if (($lastexitcode -ne 0)) {
     exit $lastexitcode

--- a/ryujinx_build.sh
+++ b/ryujinx_build.sh
@@ -6,7 +6,7 @@ SMASH_APPLICATION_PATH="C:\Users\Jdsam\Downloads\Super Smash Bros. Ultimate (Wor
 RYUJINX_SMASH_SKYLINE_PLUGINS_PATH="/mnt/c/Users/Jdsam/AppData/Roaming/Ryujinx/mods/contents/01006a800016e000/romfs/skyline/plugins"
 
 # Build with release feature
-cargo skyline build --release --features layout_arc_from_file
+RUSTFLAGS=-g cargo skyline build --release --features layout_arc_from_file
 
 # Copy over to plugins path
 cp target/aarch64-skyline-switch/release/libtraining_modpack.nro $RYUJINX_SMASH_SKYLINE_PLUGINS_PATH


### PR DESCRIPTION
We should leave debugging symbols in our NROs so we can quickly see what function we're calling from in crash reports rather than finding the exact plugin and then finding the location in Ghidra. Just tested it, we just need to set RUSTFLAGS=-g and that's it! The binary size doesn't seem to increase too much. Tested via setting a bogus external function:

```rust
extern "C" {
    #[link_name = "\u{1}blingus"]
    pub fn blingus();
}

fn once_per_frame_per_fighter(
    module_accessor: &mut app::BattleObjectModuleAccessor,
    category: i32,
) {
    if category != FIGHTER_PAD_COMMAND_CATEGORY1 {
        return;
    }

    unsafe {
        if menu::menu_condition() {
            blingus();
...
```

Crash report gave: 
```
        FP:                      0000000000000000
        LR:                      00000008c164f2d8 (training_modpack + 0xe12d8) (handle_get_command_flag_cat + 0x1604)
        SP:                      0000004667f33370
        PC:                      0000000000000000
```