### PR TITLE
Fix crash if the TRAINING_MODPACK_ROOT path doesn't already exist

### DIFF
--- a/src/common/release.rs
+++ b/src/common/release.rs
@@ -11,7 +11,11 @@ use zip::ZipArchive;
 
 lazy_static! {
     pub static ref CURRENT_VERSION: Mutex<String> =
-        Mutex::new(get_current_version().expect("Could not find current modpack version!\n"));
+        Mutex::new(
+            match get_current_version() {
+                Ok(v) => v,
+                Err(e) => panic!("Could not find current modpack version!: {}", e)
+        });
 }
 
 #[derive(Debug)]

--- a/src/common/release.rs
+++ b/src/common/release.rs
@@ -10,12 +10,10 @@ use serde_json::Value;
 use zip::ZipArchive;
 
 lazy_static! {
-    pub static ref CURRENT_VERSION: Mutex<String> =
-        Mutex::new(
-            match get_current_version() {
-                Ok(v) => v,
-                Err(e) => panic!("Could not find current modpack version!: {}", e)
-        });
+    pub static ref CURRENT_VERSION: Mutex<String> = Mutex::new(match get_current_version() {
+        Ok(v) => v,
+        Err(e) => panic!("Could not find current modpack version!: {}", e),
+    });
 }
 
 #[derive(Debug)]

--- a/training_mod_consts/src/config.rs
+++ b/training_mod_consts/src/config.rs
@@ -64,6 +64,11 @@ impl TrainingModpackConfig {
         if fs::metadata(TRAINING_MODPACK_TOML_PATH).is_ok() {
             Err(io::Error::from(io::ErrorKind::AlreadyExists).into())
         } else {
+            if !fs::metadata(TRAINING_MODPACK_ROOT).is_ok() {
+                // Root path doesn't exist, create it before trying to make the file
+                println!("Creating directory...");
+                fs::create_dir_all(TRAINING_MODPACK_ROOT)?;
+            }
             let default_config: TrainingModpackConfig = TrainingModpackConfig::new();
             let contents = toml::to_string(&default_config)?;
             fs::write(TRAINING_MODPACK_TOML_PATH, contents)?;


### PR DESCRIPTION
Addresses this crash
![image](https://github.com/jugeeya/UltimateTrainingModpack/assets/40246417/8542d0af-9c56-4652-8aa2-a39152d7217b)

The issue was that we didn't check to see if the TRAINING_MODPACK_ROOT path before trying to write the toml config file.