### PR TITLE
Add dialog_ok if the user declines the update

### DIFF
--- a/src/common/release.rs
+++ b/src/common/release.rs
@@ -212,7 +212,7 @@ pub fn perform_version_check() {
                     "This update has been declined.\n\n\
                     If you'd like to disable update checking in the future,\
                     please adjust the 'Auto-Update' setting in the Modpack menu."
-                    .to_string()
+                        .to_string(),
                 );
             }
         }

--- a/src/common/release.rs
+++ b/src/common/release.rs
@@ -208,6 +208,12 @@ pub fn perform_version_check() {
                 }
             } else {
                 info!("User declined the update.");
+                dialog::dialog_ok(
+                    "This update has been declined.\n\n\
+                    If you'd like to disable update checking in the future,\n\
+                    please adjust the 'Auto-Update' setting in the Modpack menu."
+                    .to_string()
+                );
             }
         }
         Err(e) => {

--- a/src/common/release.rs
+++ b/src/common/release.rs
@@ -210,7 +210,7 @@ pub fn perform_version_check() {
                 info!("User declined the update.");
                 dialog::dialog_ok(
                     "This update has been declined.\n\n\
-                    If you'd like to disable update checking in the future,\n\
+                    If you'd like to disable update checking in the future,\
                     please adjust the 'Auto-Update' setting in the Modpack menu."
                     .to_string()
                 );


### PR DESCRIPTION
Adds an informational dialog_ok() box if a user declines an update, letting them know that they can disable update checks in the modpack menu.

![2023082318224200-0E7DF678130F4F0FA2C88AE72B47AFDF](https://github.com/jugeeya/UltimateTrainingModpack/assets/40246417/6149b3f6-06ed-438f-b151-f28fd088b018)
