### PR TITLE
Don't Use Exclusive Button Combos

### DIFF
--- a/src/common/button_config.rs
+++ b/src/common/button_config.rs
@@ -7,7 +7,6 @@ use crate::training::ui::menu::VANILLA_MENU_ACTIVE;
 
 use lazy_static::lazy_static;
 use parking_lot::Mutex;
-use strum::IntoEnumIterator;
 use strum_macros::EnumIter;
 
 use super::menu::QUICK_MENU_ACTIVE;

--- a/src/common/button_config.rs
+++ b/src/common/button_config.rs
@@ -84,7 +84,7 @@ lazy_static! {
     static ref START_HOLD_FRAMES: Mutex<u32> = Mutex::new(0);
 }
 
-fn combo_passes(p1_controller: Controller, combo: ButtonCombo) -> bool {
+fn _combo_passes(p1_controller: Controller, combo: ButtonCombo) -> bool {
     unsafe {
         let combo_keys = get_combo_keys(combo).to_vec();
         let mut this_combo_passes = false;
@@ -109,14 +109,7 @@ fn combo_passes(p1_controller: Controller, combo: ButtonCombo) -> bool {
     }
 }
 
-pub fn _combo_passes_exclusive(p1_controller: Controller, combo: ButtonCombo) -> bool {
-    let other_combo_passes = ButtonCombo::iter()
-        .filter(|other_combo| *other_combo != combo)
-        .any(|other_combo| combo_passes(p1_controller, other_combo));
-    combo_passes(p1_controller, combo) && !other_combo_passes
-}
-
-pub fn combo_passes_exclusive(combo: ButtonCombo) -> bool {
+pub fn combo_passes(combo: ButtonCombo) -> bool {
     unsafe {
         let button_combo_requests = &mut *BUTTON_COMBO_REQUESTS.data_ptr();
         let passes = button_combo_requests.get_mut(&combo);
@@ -178,7 +171,7 @@ pub fn handle_final_input_mapping(player_idx: i32, controller_struct: &mut SomeC
             .iter_mut()
             .for_each(|(combo, is_request)| {
                 if !*is_request {
-                    *is_request = _combo_passes_exclusive(*p1_controller, *combo);
+                    *is_request = _combo_passes(*p1_controller, *combo);
                     if *combo == button_config::ButtonCombo::OpenMenu && start_menu_request {
                         *is_request = true;
                     }

--- a/src/common/menu.rs
+++ b/src/common/menu.rs
@@ -20,7 +20,7 @@ pub const MENU_CLOSE_WAIT_FRAMES: u32 = 15;
 pub static mut QUICK_MENU_ACTIVE: bool = false;
 
 pub unsafe fn menu_condition() -> bool {
-    button_config::combo_passes_exclusive(button_config::ButtonCombo::OpenMenu)
+    button_config::combo_passes(button_config::ButtonCombo::OpenMenu)
 }
 
 pub fn load_from_file() {

--- a/src/training/input_record.rs
+++ b/src/training/input_record.rs
@@ -182,10 +182,10 @@ pub unsafe fn get_command_flag_cat(module_accessor: &mut BattleObjectModuleAcces
     CURRENT_RECORD_SLOT = MENU.recording_slot.into_idx();
 
     if entry_id_int == 0 && !fighter_is_nana {
-        if button_config::combo_passes_exclusive(button_config::ButtonCombo::InputPlayback) {
+        if button_config::combo_passes(button_config::ButtonCombo::InputPlayback) {
             playback(MENU.playback_button_slots.get_random().into_idx());
         } else if MENU.record_trigger.contains(RecordTrigger::COMMAND)
-            && button_config::combo_passes_exclusive(button_config::ButtonCombo::InputRecord)
+            && button_config::combo_passes(button_config::ButtonCombo::InputRecord)
         {
             lockout_record();
         }

--- a/src/training/save_states.rs
+++ b/src/training/save_states.rs
@@ -413,8 +413,7 @@ pub unsafe fn save_states(module_accessor: &mut app::BattleObjectModuleAccessor)
         && is_dead(module_accessor);
     let mut triggered_reset: bool = false;
     if !is_operation_cpu(module_accessor) && !fighter_is_nana {
-        triggered_reset =
-            button_config::combo_passes(button_config::ButtonCombo::LoadState);
+        triggered_reset = button_config::combo_passes(button_config::ButtonCombo::LoadState);
     }
     if (autoload_reset || triggered_reset) && !fighter_is_nana {
         if save_state.state == NoAction {

--- a/src/training/save_states.rs
+++ b/src/training/save_states.rs
@@ -414,7 +414,7 @@ pub unsafe fn save_states(module_accessor: &mut app::BattleObjectModuleAccessor)
     let mut triggered_reset: bool = false;
     if !is_operation_cpu(module_accessor) && !fighter_is_nana {
         triggered_reset =
-            button_config::combo_passes_exclusive(button_config::ButtonCombo::LoadState);
+            button_config::combo_passes(button_config::ButtonCombo::LoadState);
     }
     if (autoload_reset || triggered_reset) && !fighter_is_nana {
         if save_state.state == NoAction {
@@ -638,7 +638,7 @@ pub unsafe fn save_states(module_accessor: &mut app::BattleObjectModuleAccessor)
     }
 
     // Save state
-    if button_config::combo_passes_exclusive(button_config::ButtonCombo::SaveState) {
+    if button_config::combo_passes(button_config::ButtonCombo::SaveState) {
         // Don't begin saving state if Nana's delayed input is captured
         MIRROR_STATE = 1.0;
         save_state_player(MENU.save_state_slot.as_idx() as usize).state = Save;


### PR DESCRIPTION
In order to ensure users can't lock themselves out of the default menu combination (B+DPadUp), let's not use exclusive button combos anymore.