### PR TITLE
Improve recording playback

### DIFF
--- a/src/training/input_record.rs
+++ b/src/training/input_record.rs
@@ -172,6 +172,7 @@ fn into_transition_term(starting_status: StartingStatus) -> i32 {
     }
 }
 
+#[allow(clippy::unnecessary_unwrap)]
 pub unsafe fn handle_recording() {
     let player_module_accessor = try_get_module_accessor(FighterId::Player);
     let cpu_module_accessor = try_get_module_accessor(FighterId::CPU);

--- a/src/training/input_record.rs
+++ b/src/training/input_record.rs
@@ -173,10 +173,12 @@ fn into_transition_term(starting_status: StartingStatus) -> i32 {
 }
 
 pub unsafe fn handle_recording() {
-    let player_module_accessor = get_module_accessor(FighterId::Player);
-    let cpu_module_accessor = get_module_accessor(FighterId::CPU);
-    handle_recording_for_fighter(&mut *player_module_accessor);
-    handle_recording_for_fighter(&mut *cpu_module_accessor);
+    let player_module_accessor = try_get_module_accessor(FighterId::Player);
+    let cpu_module_accessor = try_get_module_accessor(FighterId::CPU);
+    if player_module_accessor.is_some() && cpu_module_accessor.is_some() {
+        handle_recording_for_fighter(&mut *player_module_accessor.unwrap());
+        handle_recording_for_fighter(&mut *cpu_module_accessor.unwrap());
+    }
 }
 
 unsafe fn handle_recording_for_fighter(module_accessor: &mut BattleObjectModuleAccessor) {

--- a/src/training/input_record.rs
+++ b/src/training/input_record.rs
@@ -172,7 +172,14 @@ fn into_transition_term(starting_status: StartingStatus) -> i32 {
     }
 }
 
-pub unsafe fn get_command_flag_cat(module_accessor: &mut BattleObjectModuleAccessor) {
+pub unsafe fn handle_recording() {
+    let player_module_accessor = get_module_accessor(FighterId::Player);
+    let cpu_module_accessor = get_module_accessor(FighterId::CPU);
+    handle_recording_for_fighter(&mut *player_module_accessor);
+    handle_recording_for_fighter(&mut *cpu_module_accessor);
+}
+
+unsafe fn handle_recording_for_fighter(module_accessor: &mut BattleObjectModuleAccessor) {
     // Allow this because sometimes we want to make sure our NNSDK doesn't have
     // an erroneous definition
     #[allow(clippy::unnecessary_cast)]

--- a/src/training/mod.rs
+++ b/src/training/mod.rs
@@ -138,7 +138,6 @@ fn once_per_frame_per_fighter(
             );
         }
 
-        input_record::get_command_flag_cat(module_accessor);
         combo::get_command_flag_cat(module_accessor);
         hitbox_visualizer::get_command_flag_cat(module_accessor);
         save_states::save_states(module_accessor);
@@ -797,6 +796,7 @@ static OPCF_OFFSET: usize = 0x06b7fdc;
 // One instruction after the CPU Control function completes
 #[skyline::hook(offset = OPCF_OFFSET, inline)]
 unsafe fn handle_once_per_cpu_frame(_ctx: &mut InlineCtx) {
+    input_record::handle_recording();
     frame_counter::tick_ingame();
     tech::hide_tech();
     // Tick notifications
@@ -881,7 +881,10 @@ pub fn training_mods() {
     // Enable Custom Stages for Training Mode
     // Specifically, we prevent a field in StageSelectInfo of the Scene that controls if the Custom Stage tab is loaded
     //  from being set to false when we load the SSS in Training Mode
-    skyline::patching::Patch::in_text(0x184d1d8).nop().unwrap();
+    static SSS_TRAINING_OFFSET: usize = 0x184d1d8;
+    skyline::patching::Patch::in_text(SSS_TRAINING_OFFSET)
+        .nop()
+        .unwrap();
 
     skyline::install_hooks!(
         // Mash airdodge/jump


### PR DESCRIPTION
Moves the function for incrementing frames and applying affects to a function that actually runs once per frame, and runs the checks symmetrically for both fighters. Fixes issues with initial short hops and hitstop messing up on recordings that most likely resulted from multiple command_flag_cat checks in the same frame.