### PR TITLE
Hide Notifications when Combo Counter is Off

### DIFF
--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -41,7 +41,7 @@ pub fn is_training_mode() -> bool {
 // FUN_71013e7be0 sets this up (13.0.1) so look here if more values are needed
 // If you need full size use gdb to look at allocator
 pub struct PauseMenu {
-    padding: [u8; 0xb60], // Unknown Values
+    padding: [u8; 0xb60],       // Unknown Values
     pub stale_move_toggle: u32, // Handles if Stale Moves are on, 0 for off, 1 for on
     unknown1: u32,
     unknown2: u32,

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -24,7 +24,7 @@ pub static mut BASE_MENU: TrainingModpackMenu = unsafe { DEFAULTS_MENU };
 pub static mut FIGHTER_MANAGER_ADDR: usize = 0;
 pub static mut ITEM_MANAGER_ADDR: usize = 0;
 pub static mut STAGE_MANAGER_ADDR: usize = 0;
-pub static mut TRAINING_MENU_ADDR: usize = 0;
+pub static mut TRAINING_MENU_ADDR: *mut PauseMenu = core::ptr::null_mut();
 
 #[cfg(not(feature = "outside_training_mode"))]
 extern "C" {

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -24,6 +24,7 @@ pub static mut BASE_MENU: TrainingModpackMenu = unsafe { DEFAULTS_MENU };
 pub static mut FIGHTER_MANAGER_ADDR: usize = 0;
 pub static mut ITEM_MANAGER_ADDR: usize = 0;
 pub static mut STAGE_MANAGER_ADDR: usize = 0;
+pub static mut TRAINING_MENU_ADDR: usize = 0;
 
 #[cfg(not(feature = "outside_training_mode"))]
 extern "C" {

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -37,6 +37,17 @@ pub fn is_training_mode() -> bool {
     true
 }
 
+#[repr(C)]
+// FUN_71013e7be0 sets this up (13.0.1) so look here if more values are needed
+// If you need full size use gdb to look at allocator
+pub struct PauseMenu {
+    padding: [u8; 0xb60], // Unknown Values
+    pub stale_move_toggle: u32, // Handles if Stale Moves are on, 0 for off, 1 for on
+    unknown1: u32,
+    unknown2: u32,
+    pub combo_display_toggle: u32, // Handles if Combo Counter displays, 0 for off, 1 for on
+}
+
 #[skyline::from_offset(*OFFSET_GET_BATTLE_OBJECT_FROM_ID as isize)]
 pub fn get_battle_object_from_id(battle_object_id: u32) -> *mut app::BattleObject;
 

--- a/src/training/mod.rs
+++ b/src/training/mod.rs
@@ -2,7 +2,7 @@ use crate::common::button_config;
 use crate::common::consts::{BuffOption, FighterId, MENU};
 use crate::common::offsets::*;
 use crate::common::{
-    dev_config, get_module_accessor, is_operation_cpu, is_training_mode, menu,
+    dev_config, get_module_accessor, is_operation_cpu, is_training_mode, menu, PauseMenu,
     FIGHTER_MANAGER_ADDR, ITEM_MANAGER_ADDR, STAGE_MANAGER_ADDR, TRAINING_MENU_ADDR,
 };
 use crate::hitbox_visualizer;
@@ -423,9 +423,8 @@ pub unsafe fn handle_add_damage(
 #[skyline::hook(offset = *OFFSET_STALE, inline)]
 unsafe fn stale_handle(ctx: &mut InlineCtx) {
     let x22 = ctx.registers[22].x.as_mut();
-    let training_structure_address = (*x22 + 0xb60) as *mut u8;
-    TRAINING_MENU_ADDR = (*x22) as usize;
-    *training_structure_address = 1;
+    TRAINING_MENU_ADDR = (*x22) as *mut PauseMenu;
+    (*TRAINING_MENU_ADDR).stale_move_toggle = 1;
 }
 
 // Set Stale Moves to On in the menu text

--- a/src/training/mod.rs
+++ b/src/training/mod.rs
@@ -438,16 +438,6 @@ unsafe fn stale_menu_handle(ctx: &mut InlineCtx) {
     *x1 = on_text_ptr;
 }
 
-// Get Combo Counter Address
-static CC_OFFSET: usize = 0x013e87dc;
-
-// One instruction after combo counter toggle register is set to 0
-#[skyline::hook(offset = CC_OFFSET, inline)]
-unsafe fn cc_handle(ctx: &mut InlineCtx) {
-    let x23 = ctx.registers[23].x.as_mut();
-    TRAINING_MENU_ADDR = (*x23) as usize;
-}
-
 #[skyline::hook(replace = SoundModule::play_se)] // hooked to prevent death sfx from playing when loading save states
 pub unsafe fn handle_se(
     module_accessor: &mut BattleObjectModuleAccessor,
@@ -920,7 +910,6 @@ pub fn training_mods() {
         clatter::hook_start_clatter,
         // Notifications
         handle_once_per_cpu_frame,
-        cc_handle,
         // Input
         handle_final_input_mapping,
         // Charge

--- a/src/training/ui/display.rs
+++ b/src/training/ui/display.rs
@@ -1,7 +1,7 @@
 use skyline::nn::ui2d::*;
 use smash::ui2d::{SmashPane, SmashTextBox};
 
-use crate::common::{menu::QUICK_MENU_ACTIVE, PauseMenu, TRAINING_MENU_ADDR};
+use crate::common::{menu::QUICK_MENU_ACTIVE, TRAINING_MENU_ADDR};
 use crate::training::ui;
 macro_rules! display_parent_fmt {
     ($x:ident) => {
@@ -23,8 +23,7 @@ macro_rules! display_txt_fmt {
 
 pub unsafe fn draw(root_pane: &Pane) {
     // Make sure the combo counter is being displayed before we draw
-    let menu = TRAINING_MENU_ADDR as *const PauseMenu;
-    let cc_displayed = (*menu).combo_display_toggle != 0;
+    let cc_displayed = (*TRAINING_MENU_ADDR).combo_display_toggle != 0;
     let notification_idx = 0;
 
     let queue = &mut ui::notifications::QUEUE;

--- a/src/training/ui/display.rs
+++ b/src/training/ui/display.rs
@@ -1,8 +1,8 @@
 use skyline::nn::ui2d::*;
 use smash::ui2d::{SmashPane, SmashTextBox};
 
-use crate::{common::menu::QUICK_MENU_ACTIVE, training::ui};
-use crate::common::TRAINING_MENU_ADDR;
+use crate::training::ui;
+use crate::common::{TRAINING_MENU_ADDR, PauseMenu, menu::QUICK_MENU_ACTIVE};
 macro_rules! display_parent_fmt {
     ($x:ident) => {
         format!("TrModDisp{}", $x).as_str()
@@ -22,9 +22,8 @@ macro_rules! display_txt_fmt {
 }
 
 pub unsafe fn draw(root_pane: &Pane) {
-    let cc_address = (TRAINING_MENU_ADDR + 0xb6c) as *const u8;
-    println!("CC Address: {:p}, CC Value: {}", cc_address, *cc_address);
-    let cc_displayed = *cc_address != 0;
+    let menu = TRAINING_MENU_ADDR as *const PauseMenu;
+    let cc_displayed = (*menu).combo_display_toggle != 0;
     let notification_idx = 0;
 
     let queue = &mut ui::notifications::QUEUE;

--- a/src/training/ui/display.rs
+++ b/src/training/ui/display.rs
@@ -22,6 +22,7 @@ macro_rules! display_txt_fmt {
 }
 
 pub unsafe fn draw(root_pane: &Pane) {
+    // Make sure the combo counter is being displayed before we draw
     let menu = TRAINING_MENU_ADDR as *const PauseMenu;
     let cc_displayed = (*menu).combo_display_toggle != 0;
     let notification_idx = 0;
@@ -32,7 +33,7 @@ pub unsafe fn draw(root_pane: &Pane) {
     root_pane
         .find_pane_by_name_recursive(display_parent_fmt!(notification_idx))
         .unwrap()
-        .set_visible(notification.is_some() && !QUICK_MENU_ACTIVE && cc_displayed); // TODO: Add check for combo counter on here
+        .set_visible(notification.is_some() && !QUICK_MENU_ACTIVE && cc_displayed);
     if notification.is_none() {
         return;
     }

--- a/src/training/ui/display.rs
+++ b/src/training/ui/display.rs
@@ -30,13 +30,19 @@ pub unsafe fn draw(root_pane: &Pane) {
     root_pane
         .find_pane_by_name_recursive(display_parent_fmt!(notification_idx))
         .unwrap()
-        .set_visible(notification.is_some() && !QUICK_MENU_ACTIVE);
+        .set_visible(notification.is_some() && !QUICK_MENU_ACTIVE && false); // TODO: Add check for combo counter on here
     if notification.is_none() {
         return;
     }
 
     let notification = notification.unwrap();
     let color = notification.color;
+
+    if true {
+        // Set the notification to drawn so we don't draw it
+        notification.set_drawn();
+        notification.force_complete();
+    }
 
     if !notification.has_drawn() {
         notification.set_drawn();

--- a/src/training/ui/display.rs
+++ b/src/training/ui/display.rs
@@ -1,8 +1,8 @@
 use skyline::nn::ui2d::*;
 use smash::ui2d::{SmashPane, SmashTextBox};
 
+use crate::common::{menu::QUICK_MENU_ACTIVE, PauseMenu, TRAINING_MENU_ADDR};
 use crate::training::ui;
-use crate::common::{TRAINING_MENU_ADDR, PauseMenu, menu::QUICK_MENU_ACTIVE};
 macro_rules! display_parent_fmt {
     ($x:ident) => {
         format!("TrModDisp{}", $x).as_str()

--- a/src/training/ui/display.rs
+++ b/src/training/ui/display.rs
@@ -2,7 +2,7 @@ use skyline::nn::ui2d::*;
 use smash::ui2d::{SmashPane, SmashTextBox};
 
 use crate::{common::menu::QUICK_MENU_ACTIVE, training::ui};
-
+use crate::common::TRAINING_MENU_ADDR;
 macro_rules! display_parent_fmt {
     ($x:ident) => {
         format!("TrModDisp{}", $x).as_str()
@@ -22,6 +22,9 @@ macro_rules! display_txt_fmt {
 }
 
 pub unsafe fn draw(root_pane: &Pane) {
+    let cc_address = (TRAINING_MENU_ADDR + 0xb6c) as *const u8;
+    println!("CC Address: {:p}, CC Value: {}", cc_address, *cc_address);
+    let cc_displayed = *cc_address != 0;
     let notification_idx = 0;
 
     let queue = &mut ui::notifications::QUEUE;
@@ -30,7 +33,7 @@ pub unsafe fn draw(root_pane: &Pane) {
     root_pane
         .find_pane_by_name_recursive(display_parent_fmt!(notification_idx))
         .unwrap()
-        .set_visible(notification.is_some() && !QUICK_MENU_ACTIVE && false); // TODO: Add check for combo counter on here
+        .set_visible(notification.is_some() && !QUICK_MENU_ACTIVE && cc_displayed); // TODO: Add check for combo counter on here
     if notification.is_none() {
         return;
     }
@@ -38,7 +41,7 @@ pub unsafe fn draw(root_pane: &Pane) {
     let notification = notification.unwrap();
     let color = notification.color;
 
-    if true {
+    if !cc_displayed {
         // Set the notification to drawn so we don't draw it
         notification.set_drawn();
         notification.force_complete();

--- a/src/training/ui/notifications.rs
+++ b/src/training/ui/notifications.rs
@@ -34,6 +34,11 @@ impl Notification {
         self.length -= 1;
     }
 
+    // Used to force the notification to be removed from queue
+    pub fn force_complete(&mut self) {
+        self.length = 0;
+    }
+
     // Returns: has_completed
     pub fn check_completed(&mut self) -> bool {
         if self.length <= 1 {


### PR DESCRIPTION
Hides notifications when Combo Counter is off, since the notification is an expansion of the Combo Counter.