### PR TITLE
Attempt to fix frame advantage values.

### DIFF
--- a/src/training/combo.rs
+++ b/src/training/combo.rs
@@ -111,7 +111,7 @@ pub unsafe fn is_enable_transition_term(
             let cpu_module_accessor = get_module_accessor(FighterId::CPU);
             if was_in_shieldstun(cpu_module_accessor) {
                 update_frame_advantage(
-                    (CPU_ACTIVE_FRAME as i64 - PLAYER_ACTIVE_FRAME as i64) as i32,
+                    ((CPU_ACTIVE_FRAME as i64 - PLAYER_ACTIVE_FRAME as i64) / 2 + 1) as i32,
                 );
             }
 


### PR DESCRIPTION
I can't get the project to build locally (complains about the rustc version with ahash, even though my rustc version is more than new enough?)

I've noticed the frame advantage values are `n * 2 - 1` where `n` is the real value we want. I'm sure there's an underlying reason why this is happening, I'm just trying to apply a temporary fix.