### PR TITLE
Fix crash when playing back w/o playback slot selected

### DIFF
--- a/training_mod_consts/src/options.rs
+++ b/training_mod_consts/src/options.rs
@@ -883,7 +883,7 @@ impl SaveStateSlot {
             SaveStateSlot::S3 => Some(2),
             SaveStateSlot::S4 => Some(3),
             SaveStateSlot::S5 => Some(4),
-            _ => panic!("Invalid value in SaveStateSlot::into_idx: {}", self),
+            _ => None,
         }
     }
 }
@@ -906,7 +906,7 @@ impl RecordSlot {
             RecordSlot::S3 => Some(2),
             RecordSlot::S4 => Some(3),
             RecordSlot::S5 => Some(4),
-            _ => panic!("Invalid value in RecordSlot::into_idx: {}", self),
+            _ => None,
         }
     }
 }
@@ -929,7 +929,7 @@ impl PlaybackSlot {
             PlaybackSlot::S3 => Some(2),
             PlaybackSlot::S4 => Some(3),
             PlaybackSlot::S5 => Some(4),
-            _ => panic!("Invalid value in PlaybackSlot::into_idx: {}", self),
+            _ => None,
         }
     }
 }


### PR DESCRIPTION
When the "Playback Button Slots" setting had no slots selected, attempting to play back an input recording using the button combination would panic. By returning None instead, pressing the input playback button combination now does nothing instead of panicking.

![image](https://github.com/jugeeya/UltimateTrainingModpack/assets/40246417/23cdec99-ed5f-4eb9-9db4-1f8d5d497149)
