### PR TITLE
Prevent button combos from triggering while either menu is open

### DIFF
--- a/src/common/button_config.rs
+++ b/src/common/button_config.rs
@@ -197,6 +197,11 @@ lazy_static! {
 
 fn _combo_passes(p1_controller: Controller, combo: ButtonCombo) -> bool {
     unsafe {
+        // Prevent button combos from passing if either the vanilla or mod menu is open
+        if VANILLA_MENU_ACTIVE || QUICK_MENU_ACTIVE {
+            return false;
+        }
+
         let combo_keys = get_combo_keys(combo).to_vec();
         let mut this_combo_passes = false;
 


### PR DESCRIPTION
Resolves #647 - if the vanilla menu or the modpack menu is up, then the other button combinations (e.g. load a save state or begin input recording) will no longer pass.