### PR TITLE
Fix non-buff spells being applied to Hero upon Save State Load

### DIFF
--- a/src/training/buff.rs
+++ b/src/training/buff.rs
@@ -104,7 +104,7 @@ pub unsafe fn handle_buffs(
 }
 
 unsafe fn buff_hero(module_accessor: &mut app::BattleObjectModuleAccessor, status: i32) -> bool {
-    let buff_vec: Vec<BuffOption> = MENU.buff_state.to_vec();
+    let buff_vec: Vec<BuffOption> = MENU.buff_state.hero_buffs().to_vec();
     if !is_buffing(module_accessor) {
         // Initial set up for spells
         start_buff(module_accessor);


### PR DESCRIPTION
When loading a save state with non-hero buffs selected in the menu, other unrelated spells (such as kaboom) would be cast instead. This PR fixes that bug by limiting the "buffs" that are applied to Hero to the correct ones.