### PR TITLE
Update GitHub Actions workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -56,13 +56,13 @@ jobs:
           cache-all-crates: true
       - name: Install Skyline
         run: |
-          cargo install --git https://github.com/Raytwo/cargo-skyline --branch std-change --force
+          cargo install --git https://github.com/jam1garner/cargo-skyline --branch master --force
           cargo-skyline skyline update-std
       - name: Build release NRO
         id: build_release
         run: RUSTFLAGS=-g cargo-skyline skyline build --release
       - name: Upload plugin artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: plugin
           path: target/aarch64-skyline-switch/release/libtraining_modpack.nro
@@ -82,12 +82,12 @@ jobs:
           cache-all-crates: true
       - name: Install Skyline
         run: |
-          cargo install --git https://github.com/Raytwo/cargo-skyline --branch std-change --force
+          cargo install --git https://github.com/jam1garner/cargo-skyline --branch master --force
           cargo-skyline skyline update-std
       - name: Build outside_training_mode NRO
         run: RUSTFLAGS=-g cargo-skyline skyline build --release --features outside_training_mode
       - name: Upload plugin (outside training mode) artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: plugin_outside_training_mode
           path: target/aarch64-skyline-switch/release/libtraining_modpack.nro
@@ -99,7 +99,7 @@ jobs:
       - plugin
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
       - name: Prepare zip
         id: prepare_zip
         env:
@@ -107,10 +107,8 @@ jobs:
         run: |
           mkdir -p ${{env.SMASH_PLUGIN_DIR}} 
           cp plugin/libtraining_modpack.nro ${{env.SMASH_PLUGIN_DIR}}/libtraining_modpack.nro
-          wget https://github.com/ultimate-research/params-hook-plugin/releases/download/v13.0.3/libparam_hook.nro
-          wget https://github.com/ultimate-research/nro-hook-plugin/releases/download/v0.4.0/libnro_hook.nro
-          cp libparam_hook.nro ${{env.SMASH_PLUGIN_DIR}}/libparam_hook.nro
-          cp libnro_hook.nro ${{env.SMASH_PLUGIN_DIR}}/libnro_hook.nro
+          curl --output-dir ${{env.SMASH_PLUGIN_DIR}} https://github.com/ultimate-research/params-hook-plugin/releases/download/v13.0.3/libparam_hook.nro
+          curl --output-dir ${{env.SMASH_PLUGIN_DIR}} https://github.com/ultimate-research/nro-hook-plugin/releases/download/v0.4.0/libnro_hook.nro
           zip -r training_modpack_beta.zip atmosphere
       - name: Delete Release
         uses: dev-drprasad/delete-tag-and-release@v0.2.1
@@ -181,7 +179,7 @@ jobs:
           files: >
             training_modpack_beta.zip
       - name: Upload zip as artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: full_build
           path: training_modpack_beta.zip 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 skyline = { git = "https://github.com/ultimate-research/skyline-rs.git" }
-skyline_smash = { git = "https://github.com/asimon-1/skyline-smash.git", branch = "13.0.3" }
+skyline_smash = { git = "https://github.com/austintraver/skyline-smash.git" }
 skyline-web = { git = "https://github.com/skyline-rs/skyline-web.git" }
 bitflags = "1.2.1"
 parking_lot = { version = "0.12.0", features = ["nightly"] }
@@ -28,7 +28,7 @@ wsl = "0.1.0"
 strum = "0.21.0"
 strum_macros = "0.21.0"
 minreq = { version = "2", features = ["https-native", "json-using-serde"] }
-sarc = { version = "1.2.0", features = [], default_features = false }
+sarc = { version = "1.2.0", features = [], default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 smush_info_shared = { git = "https://github.com/jam1garner/smush_info_shared.git" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 #![feature(exclusive_range_pattern)]
 #![feature(c_variadic)]
 #![allow(stable_features)]
+#![feature(stmt_expr_attributes)]
 #![feature(pointer_byte_offsets)]
 #![allow(
     clippy::borrow_interior_mutable_const,

--- a/src/training/ui/mod.rs
+++ b/src/training/ui/mod.rs
@@ -154,6 +154,7 @@ unsafe fn handle_layout_arc_malloc(ctx: &mut skyline::hooks::InlineCtx) {
     let inject_arc_size: u64;
 
     #[cfg(feature = "layout_arc_from_file")]
+    #[allow(static_mut_refs)]
     {
         let inject_arc_from_file = std::fs::read(LAYOUT_ARC_PATH).unwrap();
         inject_arc_size = inject_arc_from_file.len() as u64;


### PR DESCRIPTION
The GitHub Action for building the modpack is broken, and builds in other pull requests are currently failing as a consequence.

This PR includes the following:
* Replace deprecated GitHub Actions with newer versions
* Adds necessary feature flags to the project crate
* Removes deprecated name `default_features` and replace it with the now-preferred `default-features`