### PR TITLE
Follow redirects in `curl` within GitHub Action

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -109,6 +109,7 @@ jobs:
           SMASH_PLUGIN_DIR: atmosphere/contents/01006A800016E000/romfs/skyline/plugins
         run: |
           curl \
+            --location \
             --no-progress-meter \
             --create-dirs \
             --output-dir ${{env.SMASH_PLUGIN_DIR}} \


### PR DESCRIPTION
The `curl` command to download `libnro_hook.nro` and `libparam_hook.nro` did not include the necessary `--location` flag to follow redirects. This resulted in the creation of 0-byte files, instead of downloading the actual files located at the provided URLs.

This PR fixes the build to include the necessary `--location` flag.