### PR TITLE
Fix bug with tech actions when holding shield

### DIFF
--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -123,6 +123,12 @@ pub fn is_airborne(module_accessor: &mut app::BattleObjectModuleAccessor) -> boo
     situation_kind == SITUATION_KIND_AIR
 }
 
+pub fn was_airborne(module_accessor: &mut app::BattleObjectModuleAccessor) -> bool {
+    let situation_kind = unsafe { StatusModule::prev_situation_kind(module_accessor) };
+
+    situation_kind == SITUATION_KIND_AIR
+}
+
 pub fn is_idle(module_accessor: &mut app::BattleObjectModuleAccessor) -> bool {
     let status_kind = unsafe { StatusModule::status_kind(module_accessor) };
 

--- a/src/training/shield.rs
+++ b/src/training/shield.rs
@@ -175,28 +175,14 @@ pub unsafe fn param_installer() {
     }
 }
 
-pub fn should_hold_shield(module_accessor: &mut app::BattleObjectModuleAccessor) -> bool {
-    // Don't let shield override input recording playback
-    unsafe {
-        if input_record::is_playback() || input_record::is_standby() {
-            return false;
-        }
-    }
-    // Mash shield
-    if mash::request_shield(module_accessor) {
-        return true;
-    }
-
+pub unsafe fn should_hold_shield(module_accessor: &mut app::BattleObjectModuleAccessor) -> bool {
     let shield_state = &read(&MENU).shield_state;
-
-    // We should hold shield if the state requires it
-    if unsafe { save_states::is_loading() }
-        || ![Shield::HOLD, Shield::INFINITE, Shield::CONSTANT].contains(shield_state)
-    {
-        return false;
-    }
-
-    true
+    !input_record::is_playback()
+        && !input_record::is_standby()
+        && !save_states::is_loading()
+        && !was_airborne(module_accessor)
+        && (mash::request_shield(module_accessor)
+            || [Shield::HOLD, Shield::INFINITE, Shield::CONSTANT].contains(shield_state))
 }
 
 #[skyline::hook(replace = smash::lua2cpp::L2CFighterCommon_sub_guard_cont)]


### PR DESCRIPTION
When shield toggle is set to "Infinite", "Hold", or "Constant" then the CPU would perform a neutral tech regardless of which tech option was selected. This PR adds a condition to `should_hold_shield()` in order to prevent that issue, and makes the function more readable.