### PR TITLE
Fix bug with Aegis swap improperly triggering on distance-based Mash Triggers

### DIFF
--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -289,6 +289,7 @@ pub unsafe fn get_player_dmg_digits(p: FighterId) -> (u8, u8, u8, u8) {
 
 pub unsafe fn get_fighter_distance() -> f32 {
     let player_module_accessor = get_module_accessor(FighterId::Player);
+    if StatusModule::status_kind(player_module_accessor) == *FIGHTER_STATUS_KIND_NONE { return f32::MAX }
     let cpu_module_accessor = get_module_accessor(FighterId::CPU);
     let player_pos = *PostureModule::pos(player_module_accessor);
     let cpu_pos = *PostureModule::pos(cpu_module_accessor);


### PR DESCRIPTION
During Aegis downb, their position is considered to be (0,0) which could improperly trigger the distance-based mash triggers. This PR fixes that bug by returning `f32::MAX` as the distance during the swap.