### PR TITLE
Fix broken auto-updates

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,7 +125,7 @@ pub fn main() {
     if !is_emulator() {
         info!("Performing version check...");
         let _updater = std::thread::Builder::new()
-            .stack_size(0x20000)
+            .stack_size(0x80000)
             .spawn(move || {
                 release::perform_version_check();
             })


### PR DESCRIPTION
Stack size was too small on the auto-update thread, which caused the modpack to crash while installing OTA updates. Bumping up the stack size allows the updates to install successfully.