### PR TITLE
Update skyline_smash dependency to point to the correct repository

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 skyline = { git = "https://github.com/ultimate-research/skyline-rs.git" }
-skyline_smash = { git = "https://github.com/austintraver/skyline-smash.git" }
+skyline_smash = { git = "https://github.com/ultimate-research/skyline-smash.git" }
 skyline-web = { git = "https://github.com/skyline-rs/skyline-web.git" }
 bitflags = "1.2.1"
 parking_lot = { version = "0.12.0", features = ["nightly"] }

--- a/training_mod_consts/Cargo.toml
+++ b/training_mod_consts/Cargo.toml
@@ -13,7 +13,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_repr = "0.1.8"
 serde_json = "1"
 skyline = { git = "https://github.com/ultimate-research/skyline-rs.git" }
-skyline_smash = { git = "https://github.com/austintraver/skyline-smash.git", optional = true }
+skyline_smash = { git = "https://github.com/ultimate-research/skyline-smash.git", optional = true }
 toml = "0.5.9"
 anyhow = "1.0.72"
 rand = { git = "https://github.com/skyline-rs/rand" }


### PR DESCRIPTION
I'm pretty sure the old skyline smash repository was moved, so I updated it to point to the correct repository.