### PR TITLE
Remove outside-training-mode

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -62,7 +62,7 @@ jobs:
         id: build_release
         run: RUSTFLAGS=-g cargo-skyline skyline build --release
       - name: Upload plugin artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: plugin
           path: target/aarch64-skyline-switch/release/libtraining_modpack.nro
@@ -74,7 +74,7 @@ jobs:
       - plugin
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: atmosphere/contents/01006A800016E000/romfs/skyline/plugins 
           merge-multiple: true
@@ -93,10 +93,7 @@ jobs:
             https://github.com/ultimate-research/nro-hook-plugin/releases/download/v0.4.0/libnro_hook.nro
           zip -r training_modpack_beta.zip atmosphere
       - name: Delete Release
-        uses: dev-drprasad/delete-tag-and-release@v0.2.1
-        with:
-          tag_name: beta 
-          delete_release: true 
+        run: gh release delete beta -y
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Update Release
@@ -161,7 +158,7 @@ jobs:
           files: >
             training_modpack_beta.zip
       - name: Upload zip as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: full_build
           path: training_modpack_beta.zip 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,7 +12,7 @@ jobs:
     name: Code Formatting
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - name: Install Rust Toolchain
         uses: dtolnay/rust-toolchain@nightly
         with:
@@ -24,7 +24,7 @@ jobs:
     name: Check, Clippy, Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - name: Install Rust Toolchain
         uses: dtolnay/rust-toolchain@nightly
         with:
@@ -45,7 +45,7 @@ jobs:
     name: Plugin NRO
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@nightly
         with:
           target: x86_64-unknown-linux-gnu

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -66,31 +66,6 @@ jobs:
         with:
           name: plugin
           path: target/aarch64-skyline-switch/release/libtraining_modpack.nro
-  plugin_outside_training_mode:
-    name: Plugin NRO (Outside Training Mode)
-    if: github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@nightly
-        with:
-          target: x86_64-unknown-linux-gnu
-      - uses: Swatinem/rust-cache@v2
-        name: Rust Cache
-        with:
-          prefix-key: "plugin"
-          cache-all-crates: true
-      - name: Install Skyline
-        run: |
-          cargo install --git https://github.com/jam1garner/cargo-skyline --branch master --force
-          cargo-skyline skyline update-std
-      - name: Build outside_training_mode NRO
-        run: RUSTFLAGS=-g cargo-skyline skyline build --release --features outside_training_mode
-      - name: Upload plugin (outside training mode) artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: plugin_outside_training_mode
-          path: target/aarch64-skyline-switch/release/libtraining_modpack.nro
   upload:
     name: Upload Beta Release
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,5 +66,4 @@ plugin-dependencies = [
 ]
 
 [features]
-outside_training_mode = []
 layout_arc_from_file = []

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -25,15 +25,9 @@ pub static ITEM_MANAGER_ADDR: RwLock<usize> = RwLock::new(0);
 pub static STAGE_MANAGER_ADDR: RwLock<usize> = RwLock::new(0);
 pub static mut TRAINING_MENU_ADDR: *mut PauseMenu = core::ptr::null_mut();
 
-#[cfg(not(feature = "outside_training_mode"))]
 extern "C" {
     #[link_name = "\u{1}_ZN3app9smashball16is_training_modeEv"]
     pub fn is_training_mode() -> bool;
-}
-
-#[cfg(feature = "outside_training_mode")]
-pub fn is_training_mode() -> bool {
-    true
 }
 
 #[repr(C)]


### PR DESCRIPTION
Not sure how but somehow the beta release was using the outside-training-mode feature. This PR removes that feature entirely, I don't think it was working anyways