### PR TITLE
Fix crashes when saving/loading save states

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "training_modpack"
-version = "6.2.0"
+version = "7.1.1"
 authors = ["jugeeya <jugeeya@live.com>"]
 edition = "2018"
 

--- a/src/common/dev_config.rs
+++ b/src/common/dev_config.rs
@@ -1,10 +1,8 @@
-use std::fs;
-
 use serde::Deserialize;
 
 use crate::common::input::*;
 use crate::consts::DEV_TOML_PATH;
-use crate::logging::info;
+use crate::filesystem;
 use training_mod_sync::*;
 
 /// Hot-reloadable configs for quicker development
@@ -40,15 +38,7 @@ pub static DEV_CONFIG: LazyLock<RwLock<DevConfig>> =
 
 impl DevConfig {
     fn load_from_toml() -> DevConfig {
-        let dev_path = DEV_TOML_PATH;
-        if fs::metadata(dev_path).is_ok() {
-            info!("Loading dev.toml configs...");
-            let dev_config_str = fs::read_to_string(dev_path)
-                .unwrap_or_else(|_| panic!("Could not read {}", dev_path));
-            return toml::from_str(&dev_config_str).expect("Could not parse dev config");
-        }
-
-        DevConfig::default()
+        filesystem::read_toml(DEV_TOML_PATH).unwrap_or_default()
     }
 }
 

--- a/src/common/filesystem.rs
+++ b/src/common/filesystem.rs
@@ -20,6 +20,11 @@ static WRITER: LazyLock<Sender<WriteMessage>> = LazyLock::new(|| {
     tx
 });
 
+pub fn init() {
+    LazyLock::force(&WRITER);
+    info!("Initialized writer thread");
+}
+
 pub fn read_toml<T: DeserializeOwned>(path: &str) -> Result<T> {
     let contents = read_to_string(path)?;
     let parsed = toml::from_str::<T>(&contents)?;

--- a/src/common/filesystem.rs
+++ b/src/common/filesystem.rs
@@ -1,0 +1,58 @@
+use std::fs::read_to_string;
+use std::sync::mpsc::{self, Sender};
+use std::sync::LazyLock;
+
+use anyhow::Result;
+use serde::{de::DeserializeOwned, Serialize};
+
+use log::{error, info};
+
+static WRITER: LazyLock<Sender<WriteMessage>> = LazyLock::new(|| {
+    let (tx, rx) = mpsc::channel::<WriteMessage>();
+    std::thread::spawn(move || {
+        for job in rx {
+            match std::fs::write(job.path, job.contents) {
+                Ok(()) => info!("Saved data to {}", job.path),
+                Err(e) => error!("Could not write data to {}: {e}", job.path),
+            }
+        }
+    });
+    tx
+});
+
+pub fn read_toml<T: DeserializeOwned>(path: &str) -> Result<T> {
+    let contents = read_to_string(path)?;
+    let parsed = toml::from_str::<T>(&contents)?;
+    Ok(parsed)
+}
+
+pub fn read_json<T: DeserializeOwned>(path: &str) -> Result<T> {
+    let contents = read_to_string(path)?;
+    let parsed = serde_json::from_str::<T>(&contents)?;
+    Ok(parsed)
+}
+
+struct WriteMessage {
+    path: &'static str,
+    contents: String,
+}
+
+pub fn write_toml<T: Serialize>(path: &'static str, data: &T) {
+    match toml::to_string_pretty(data) {
+        Ok(contents) => send_write_message(path, contents),
+        Err(e) => error!("Could not serialize data for {path}: {e}"),
+    }
+}
+
+pub fn write_json<T: Serialize>(path: &'static str, data: &T) {
+    match serde_json::to_string_pretty(data) {
+        Ok(contents) => send_write_message(path, contents),
+        Err(e) => error!("Could not serialize data for {path}: {e}"),
+    }
+}
+
+fn send_write_message(path: &'static str, contents: String) {
+    if let Err(e) = WRITER.send(WriteMessage { path, contents }) {
+        error!("Could not queue write to {path}: {e}");
+    }
+}

--- a/src/common/menu.rs
+++ b/src/common/menu.rs
@@ -1,12 +1,12 @@
 use std::collections::HashMap;
 use std::fs;
-use std::io::BufReader;
 
 use skyline::nn::hid::GetNpadStyleSet;
 
 use crate::common::{button_config, ButtonConfig};
 use crate::common::{DEFAULTS_MENU, MENU};
 use crate::events::{Event, EVENT_QUEUE};
+use crate::filesystem;
 use crate::input::{ButtonBitfield, ControllerStyle, MappedInputs, SomeControllerStruct};
 use crate::logging::*;
 use crate::training::frame_counter;
@@ -28,22 +28,18 @@ pub fn load_from_file() {
     // Note that this function requires a larger stack size
     // With the switch default, it'll crash w/o a helpful error message
     info!("Checking for previous menu in {MENU_OPTIONS_PATH}...");
-    let err_msg = format!("Could not read {}", MENU_OPTIONS_PATH);
     if fs::metadata(MENU_OPTIONS_PATH).is_ok() {
-        let menu_conf = fs::File::open(MENU_OPTIONS_PATH).expect(&err_msg);
-        let reader = BufReader::new(menu_conf);
-        if let Ok(menu_conf_json) = serde_json::from_reader::<BufReader<_>, MenuJsonStruct>(reader)
-        {
-            assign(&MENU, menu_conf_json.menu);
-            assign(&DEFAULTS_MENU, menu_conf_json.defaults_menu);
-            info!("Previous menu found. Loading...");
-        } else {
-            warn!("Previous menu found but is invalid. Deleting...");
-            let err_msg = format!(
-                "{} has invalid schema but could not be deleted!",
-                MENU_OPTIONS_PATH
-            );
-            fs::remove_file(MENU_OPTIONS_PATH).expect(&err_msg);
+        match filesystem::read_json::<MenuJsonStruct>(MENU_OPTIONS_PATH) {
+            Ok(menu_conf_json) => {
+                assign(&MENU, menu_conf_json.menu);
+                assign(&DEFAULTS_MENU, menu_conf_json.defaults_menu);
+                info!("Previous menu found. Loading...");
+            }
+            Err(e) => {
+                warn!("Previous menu found at {MENU_OPTIONS_PATH} but could not be loaded: {e}");
+                info!("Deleting previous menu file so it can be recreated");
+                fs::remove_file(MENU_OPTIONS_PATH).expect("Could not remove invalid menu file!");
+            }
         }
     } else {
         info!("No previous menu file found.");
@@ -64,14 +60,7 @@ pub fn set_menu_from_json(message: &str) {
         // Includes both MENU and DEFAULTS_MENU
         assign(&MENU, message_json.menu);
         assign(&DEFAULTS_MENU, message_json.defaults_menu);
-        std::thread::spawn(move || {
-            fs::write(
-                MENU_OPTIONS_PATH,
-                serde_json::to_string_pretty(&message_json)
-                    .expect("Could not serialize menu settings"),
-            )
-            .expect("Failed to write menu settings file");
-        });
+        filesystem::write_json(MENU_OPTIONS_PATH, &message_json);
     } else {
         skyline::error::show_error(
             0x70,

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -14,6 +14,7 @@ pub mod consts;
 pub mod dev_config;
 pub mod dialog;
 pub mod events;
+pub mod filesystem;
 pub mod input;
 pub mod menu;
 pub mod offsets;

--- a/src/training/mod.rs
+++ b/src/training/mod.rs
@@ -7,6 +7,7 @@ use crate::common::{
     dev_config, is_operation_cpu, is_training_mode, menu, try_get_module_accessor, PauseMenu,
     FIGHTER_MANAGER_ADDR, ITEM_MANAGER_ADDR, STAGE_MANAGER_ADDR, TRAINING_MENU_ADDR,
 };
+use crate::filesystem;
 use crate::hitbox_visualizer;
 use crate::input::*;
 use crate::logging::*;
@@ -946,6 +947,7 @@ pub fn training_mods() {
     ptrainer::init();
     kirby::init();
     tech::init();
+    filesystem::init();
 
     #[cfg(debug_assertions)]
     debug::init();

--- a/src/training/reset.rs
+++ b/src/training/reset.rs
@@ -33,11 +33,7 @@ fn should_reset(module_accessor: &mut app::BattleObjectModuleAccessor) -> bool {
     }
 
     // Only reset automatically on training mode reset
-    if prev_status != *FIGHTER_STATUS_KIND_NONE {
-        return false;
-    }
-
-    true
+    prev_status == *FIGHTER_STATUS_KIND_NONE
 }
 
 pub fn on_reset() {

--- a/src/training/save_states.rs
+++ b/src/training/save_states.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use log::{error, info};
+use log::{info, warn};
 use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
 use smash::app::{self, lua_bind::*, ArticleOperationTarget, Item};
@@ -9,7 +9,6 @@ use smash::hash40;
 use smash::lib::lua_const::*;
 use smash::phx::{Hash40, Vector3f};
 use std::ptr;
-use std::sync::atomic::{AtomicBool, Ordering};
 use training_mod_consts::{CharacterItem, SaveDamage, SaveStateSlot};
 
 use SaveState::*;
@@ -24,6 +23,7 @@ use crate::common::consts::RecordTrigger;
 use crate::common::consts::SaveStateMirroring;
 //TODO: Cleanup above
 use crate::common::consts::SAVE_STATES_TOML_PATH;
+use crate::common::filesystem;
 use crate::common::is_dead;
 use crate::common::try_get_module_accessor;
 use crate::common::MENU;
@@ -158,40 +158,14 @@ pub fn load_from_file() -> SaveStateSlots {
     };
 
     info!("Checking for previous save state settings in {SAVE_STATES_TOML_PATH}...");
-    if std::fs::metadata(SAVE_STATES_TOML_PATH).is_err() {
-        return defaults;
-    }
-
-    info!("Previous save state settings found. Loading...");
-    if let Ok(data) = std::fs::read_to_string(SAVE_STATES_TOML_PATH) {
-        let input_slots = toml::from_str::<SaveStateSlots>(&data);
-        if let Ok(input_slots) = input_slots {
-            return input_slots;
-        }
-    }
-
-    defaults
+    filesystem::read_toml(SAVE_STATES_TOML_PATH).unwrap_or_else(|e| {
+        warn!("Could not load previous save state settings! {e}");
+        defaults
+    })
 }
 
-static SAVE_TO_FILE_IN_PROGRESS: AtomicBool = AtomicBool::new(false);
-
-pub unsafe fn save_to_file() {
-    if SAVE_TO_FILE_IN_PROGRESS
-        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
-        .is_err()
-    {
-        info!("save_to_file: write already in progress, skipping");
-        return;
-    }
-
-    let save_states_str = toml::to_string_pretty(&*SAVE_STATE_SLOTS.data_ptr())
-        .expect("Error serializing save state information");
-    match std::fs::write(SAVE_STATES_TOML_PATH, save_states_str) {
-        Ok(()) => info!("Saved save state information to {SAVE_STATES_TOML_PATH}"),
-        Err(e) => error!("Could not write save state information to {SAVE_STATES_TOML_PATH}: {e}"),
-    }
-
-    SAVE_TO_FILE_IN_PROGRESS.store(false, Ordering::SeqCst);
+fn save_to_file(save_state_slots: SaveStateSlots) {
+    filesystem::write_toml(SAVE_STATES_TOML_PATH, &save_state_slots);
 }
 
 unsafe fn save_state_player(slot: usize) -> &'static mut SavedState {
@@ -780,7 +754,9 @@ pub unsafe fn save_states(module_accessor: &mut app::BattleObjectModuleAccessor)
         if save_state_player(selected_slot).state != Save
             && save_state_cpu(selected_slot).state != Save
         {
-            std::thread::spawn(move || save_to_file());
+            // Copy here on the game thread, the only mutator of SAVE_STATE_SLOTS, to avoid races.
+            let save_state_slots_copy = *SAVE_STATE_SLOTS.data_ptr();
+            save_to_file(save_state_slots_copy);
         }
     }
 }


### PR DESCRIPTION
Instead of spawning a new thread every time we want to write to the SD card, use a single persistent writer thread and send it messages through a channel. This prevents concurrent writes and the spawning of too many child threads.